### PR TITLE
Add composer install to travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  
+before_script:
+  - composer install


### PR DESCRIPTION
Actually no tests are executed on travis as travis does not run composer install anymore by default
