### PR TITLE
Phpdoc now same as actual return type.

### DIFF
--- a/lib/Tmdb/Model/Movie.php
+++ b/lib/Tmdb/Model/Movie.php
@@ -525,7 +525,7 @@ class Movie extends AbstractModel
     }
 
     /**
-     * @return GenericCollection
+     * @return GenericCollection|Company[]
      */
     public function getProductionCompanies()
     {
@@ -544,7 +544,7 @@ class Movie extends AbstractModel
     }
 
     /**
-     * @return GenericCollection
+     * @return GenericCollection|Country[]
      */
     public function getProductionCountries()
     {
@@ -624,7 +624,7 @@ class Movie extends AbstractModel
     }
 
     /**
-     * @return GenericCollection
+     * @return GenericCollection|SpokenLanguage[]
      */
     public function getSpokenLanguages()
     {
@@ -795,7 +795,7 @@ class Movie extends AbstractModel
     }
 
     /**
-     * @return GenericCollection
+     * @return GenericCollection|Keyword[]
      */
     public function getKeywords()
     {


### PR DESCRIPTION
Hey there Michael,

thanks for your efforts I love the lib (although I'm fighting with serializing all the custom collections). Had a minor annoyance with my IDE due to wrong PHPDoc. Easy fix.

Cheers,
Michael.

![wrong-return-type](https://cloud.githubusercontent.com/assets/2168701/3670863/fc1282ec-1248-11e4-967b-c8af5069ae05.png)
