### PR TITLE
Add a removeSubscriber method to the HttpClient

### DIFF
--- a/lib/Tmdb/HttpClient/HttpClient.php
+++ b/lib/Tmdb/HttpClient/HttpClient.php
@@ -280,6 +280,20 @@ class HttpClient
     }
 
     /**
+     * Remove a subscriber
+     *
+     * @param EventSubscriberInterface $subscriber
+     */
+    public function removeSubscriber(EventSubscriberInterface $subscriber)
+    {
+        if ($subscriber instanceof HttpClientEventSubscriber) {
+            $subscriber->attachHttpClient($this);
+        }
+
+        $this->eventDispatcher->removeSubscriber($subscriber);
+    }
+
+    /**
      * @return GuestSessionToken|SessionToken
      */
     public function getSessionToken()

--- a/test/Tmdb/Tests/HttpClient/HttpClientTest.php
+++ b/test/Tmdb/Tests/HttpClient/HttpClientTest.php
@@ -161,6 +161,33 @@ class HttpClientTest extends TestCase
     /**
      * @test
      */
+    public function shouldDeregisterSubscribers()
+    {
+        $this->eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->client  = new Client(new ApiToken('abcdef'), [
+            'adapter'          => $this->adapter,
+            'event_dispatcher' => $this->eventDispatcher
+        ]);
+        $this->testApi = new TestApi($this->client);
+
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('addSubscriber')
+        ;
+
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('removeSubscriber')
+        ;
+
+        $subscriber = $this->getMock('Symfony\Component\EventDispatcher\EventSubscriberInterface');
+        $this->testApi->addSubscriber($subscriber);
+        $this->testApi->removeSubscriber($subscriber);
+    }
+
+    /**
+     * @test
+     */
     public function shouldBeAbleToOverrideAdapter()
     {
         $httpClient = new HttpClient([
@@ -221,5 +248,10 @@ class TestApi extends AbstractApi
     public function addSubscriber($event)
     {
         $this->client->getHttpClient()->addSubscriber($event);
+    }
+
+    public function removeSubscriber($event)
+    {
+        $this->client->getHttpClient()->removeSubscriber($event);
     }
 }


### PR DESCRIPTION
Useful when you'd like to remove a plugin after adding it.