### PR TITLE
Bugfix: MovieCredit must have Job and Department to fetch all info

### DIFF
--- a/lib/Tmdb/Model/Person/MovieCredit.php
+++ b/lib/Tmdb/Model/Person/MovieCredit.php
@@ -66,6 +66,16 @@ class MovieCredit extends AbstractModel
      */
     private $posterImage;
 
+    /**
+     * @var string
+     */
+    private $job;
+
+    /**
+     * @var string
+     */
+    private $department;
+
     public static $properties = [
         'adult',
         'character',
@@ -74,7 +84,9 @@ class MovieCredit extends AbstractModel
         'original_title',
         'poster_path',
         'release_date',
-        'title'
+        'title',
+        'job',
+        'department'
     ];
 
     /**
@@ -250,5 +262,43 @@ class MovieCredit extends AbstractModel
     public function getTitle()
     {
         return $this->title;
+    }
+
+    /**
+     * @param  string $job
+     * @return $this
+     */
+    public function setJob($job)
+    {
+        $this->job = $job;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getJob()
+    {
+        return $this->job;
+    }
+
+    /**
+     * @param  string $department
+     * @return $this
+     */
+    public function setDepartment($department)
+    {
+        $this->department = $department;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDepartment()
+    {
+        return $this->department;
     }
 }


### PR DESCRIPTION
Hi,

I found a bug when I use the PeopleRepository like:
```
$person= new PeopleRepository()->load(1100); //ex. Arnold Schwarzenegger
```
and then want to get the movies where this person was in crew like:

```
$person $person->getMovieCredits()->getCrew();
```

I got a list of MovieCredit (I suppose this is a common Object to contain both, Cast and Crew Credits) which have no properties for job and departments.

This Pull Request just fix this.
