### PR TITLE
Use TMDB namespace prefix in psr-4 autolaoder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "monolog/monolog": "Required if you want to make use of logging features."
     },
     "autoload": {
-        "psr-4": { "": "lib/" }
+        "psr-4": { "Tmdb\\": "lib/Tmdb" }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Using an empty namespace prefix is bad for performance, see `composer validate --strict`.