### PR TITLE
Test support for Symfony 2.4/2.6 through 3.0 and require support of PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ matrix:
     - php: 7.0
       env: [SF_EVT_DISPATCHER_VERSION="3.0.*", SF_OPT_RESOLVER_VERSION="3.0.*"]
   allow_failures:
-    - php: 7.0
     - php: nightly
     - php: hhvm
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,34 @@ language: php
 php:
   - 5.4
   - 5.5
-  - 5.6
-  - 7.0
   - nightly
   - hhvm
-  
+
 before_script:
   - composer self-update
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/event-dispatcher:${SF_EVT_DISPATCHER_VERSION} symfony/options-resolver:${SF_OPT_RESOLVER_VERSION}; fi;
   - composer install --no-interaction --prefer-source --dev
 
 script: phpunit --coverage-text --coverage-clover=coverage.clover --verbose
 
 matrix:
+  include:
+    - php: 5.6
+      env: [SF_EVT_DISPATCHER_VERSION="2.4.*", SF_OPT_RESOLVER_VERSION="2.6.*"]
+    - php: 5.6
+      env: [SF_EVT_DISPATCHER_VERSION="2.7.*", SF_OPT_RESOLVER_VERSION="2.7.*"]
+    - php: 5.6
+      env: [SF_EVT_DISPATCHER_VERSION="2.8.*", SF_OPT_RESOLVER_VERSION="2.8.*"]
+    - php: 5.6
+      env: [SF_EVT_DISPATCHER_VERSION="3.0.*", SF_OPT_RESOLVER_VERSION="3.0.*"]
+    - php: 7.0
+      env: [SF_EVT_DISPATCHER_VERSION="2.4.*", SF_OPT_RESOLVER_VERSION="2.6.*"]
+    - php: 7.0
+      env: [SF_EVT_DISPATCHER_VERSION="2.7.*", SF_OPT_RESOLVER_VERSION="2.7.*"]
+    - php: 7.0
+      env: [SF_EVT_DISPATCHER_VERSION="2.8.*", SF_OPT_RESOLVER_VERSION="2.8.*"]
+    - php: 7.0
+      env: [SF_EVT_DISPATCHER_VERSION="3.0.*", SF_OPT_RESOLVER_VERSION="3.0.*"]
   allow_failures:
     - php: 7.0
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "require": {
         "php": ">=5.4.0",
         "ext-curl": "*",
-        "symfony/event-dispatcher": "~2.4",
-        "symfony/options-resolver": "~2.6",
+        "symfony/event-dispatcher": ">=2.4,<4",
+        "symfony/options-resolver": ">=2.6,<4",
         "guzzlehttp/guzzle": "~5.0",
         "guzzlehttp/cache-subscriber": "~0.1@dev",
         "guzzlehttp/log-subscriber": "~1.0",


### PR DESCRIPTION
I'd like to use this library in a Symfony 3, PHP 7 project. This changeset allows Symfony 3 components to be installed, tests Symfony 2.4/2.6 through 3.0 and requires that the tests pass for PHP 7.