### PR TITLE
Check correct Symfony component version environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ php:
 
 before_script:
   - composer self-update
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/event-dispatcher:${SF_EVT_DISPATCHER_VERSION} symfony/options-resolver:${SF_OPT_RESOLVER_VERSION}; fi;
+  - if [ "$SF_EVT_DISPATCHER_VERSION" != "" ]; then composer require --no-update symfony/event-dispatcher:${SF_EVT_DISPATCHER_VERSION}; fi;
+  - if [ "$SF_OPT_RESOLVER_VERSION" != "" ];   then composer require --no-update symfony/options-resolver:${SF_OPT_RESOLVER_VERSION};   fi;
   - composer install --no-interaction --prefer-source --dev
 
 script: phpunit --coverage-text --coverage-clover=coverage.clover --verbose


### PR DESCRIPTION
I was checking an earlier version that used the `$SYMFONY_VERSION` environment variable. Result: the library wasn't actually tested against the given versions. :sweat_smile:  After merging this commit, it will be. And no breakage :clap: