### PR TITLE
Add new Genre API endpoints.

### DIFF
--- a/examples/genres/api/allmovies.php
+++ b/examples/genres/api/allmovies.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of the Tmdb PHP API created by Michael Roterman.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Tmdb
+ * @author Michael Roterman <michael@wtfz.net>
+ * @copyright (c) 2013, Michael Roterman
+ * @version 0.0.1
+ */
+require_once '../../../vendor/autoload.php';
+require_once '../../../apikey.php';
+
+$token  = new \Tmdb\ApiToken(TMDB_API_KEY);
+$client = new \Tmdb\Client($token);
+
+$genres = $client->getGenresApi()->getMovieGenres();
+
+var_dump($genres);

--- a/examples/genres/api/alltv.php
+++ b/examples/genres/api/alltv.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of the Tmdb PHP API created by Michael Roterman.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Tmdb
+ * @author Michael Roterman <michael@wtfz.net>
+ * @copyright (c) 2013, Michael Roterman
+ * @version 0.0.1
+ */
+require_once '../../../vendor/autoload.php';
+require_once '../../../apikey.php';
+
+$token  = new \Tmdb\ApiToken(TMDB_API_KEY);
+$client = new \Tmdb\Client($token);
+
+$genres = $client->getGenresApi()->getTvGenres();
+
+var_dump($genres);

--- a/examples/genres/model/allmovies.php
+++ b/examples/genres/model/allmovies.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of the Tmdb PHP API created by Michael Roterman.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Tmdb
+ * @author Michael Roterman <michael@wtfz.net>
+ * @copyright (c) 2013, Michael Roterman
+ * @version 0.0.1
+ */
+require_once '../../../vendor/autoload.php';
+require_once '../../../apikey.php';
+
+$token  = new \Tmdb\ApiToken(TMDB_API_KEY);
+$client = new \Tmdb\Client($token);
+
+$repository = new \Tmdb\Repository\GenreRepository($client);
+$genres     = $repository->loadMovieCollection();
+
+foreach ($genres as $genre) {
+    var_dump($genre);
+}

--- a/examples/genres/model/alltv.php
+++ b/examples/genres/model/alltv.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of the Tmdb PHP API created by Michael Roterman.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package Tmdb
+ * @author Michael Roterman <michael@wtfz.net>
+ * @copyright (c) 2013, Michael Roterman
+ * @version 0.0.1
+ */
+require_once '../../../vendor/autoload.php';
+require_once '../../../apikey.php';
+
+$token  = new \Tmdb\ApiToken(TMDB_API_KEY);
+$client = new \Tmdb\Client($token);
+
+$repository = new \Tmdb\Repository\GenreRepository($client);
+$genres     = $repository->loadTvCollection();
+
+foreach ($genres as $genre) {
+    var_dump($genre);
+}

--- a/lib/Tmdb/Api/Genres.php
+++ b/lib/Tmdb/Api/Genres.php
@@ -47,7 +47,12 @@ class Genres extends AbstractApi
      */
     public function getGenres(array $parameters = [], array $headers = [])
     {
-        return $this->get('genre/list', $parameters, $headers);
+        $data = array_merge(
+            $this->getMovieGenres($parameters, $headers),
+            $this->getTvGenres($parameters, $headers)
+        );
+        
+        return $data;
     }
 
     /**

--- a/lib/Tmdb/Api/Genres.php
+++ b/lib/Tmdb/Api/Genres.php
@@ -51,6 +51,30 @@ class Genres extends AbstractApi
     }
 
     /**
+     * Get the list of movie genres.
+     *
+     * @param  array $parameters
+     * @param  array $headers
+     * @return mixed
+     */
+    public function getMovieGenres(array $parameters = [], array $headers = [])
+    {
+        return $this->get('genre/movie/list', $parameters, $headers);
+    }
+
+    /**
+     * Get the list of TV genres.
+     *
+     * @param  array $parameters
+     * @param  array $headers
+     * @return mixed
+     */
+    public function getTvGenres(array $parameters = [], array $headers = [])
+    {
+        return $this->get('genre/tv/list', $parameters, $headers);
+    }
+
+    /**
      * Get the list of movies for a particular genre by id. By default, only movies with 10 or more votes are included.
      *
      * @param $genre_id

--- a/lib/Tmdb/Repository/GenreRepository.php
+++ b/lib/Tmdb/Repository/GenreRepository.php
@@ -52,6 +52,34 @@ class GenreRepository extends AbstractRepository
     }
 
     /**
+     * Get the list of movie genres.
+     *
+     * @param  array             $parameters
+     * @param  array             $headers
+     * @return GenericCollection
+     */
+    public function loadMovieCollection(array $parameters = [], array $headers = [])
+    {
+        return $this->createCollection(
+            $this->getApi()->getMovieGenres($parameters, $headers)
+        );
+    }
+
+    /**
+     * Get the list of tv genres.
+     *
+     * @param  array             $parameters
+     * @param  array             $headers
+     * @return GenericCollection
+     */
+    public function loadTvCollection(array $parameters = [], array $headers = [])
+    {
+        return $this->createCollection(
+            $this->getApi()->getTvGenres($parameters, $headers)
+        );
+    }
+
+    /**
      * Get the list of movies for a particular genre by id.
      * By default, only movies with 10 or more votes are included.
      *

--- a/test/Tmdb/Tests/Api/GenresTest.php
+++ b/test/Tmdb/Tests/Api/GenresTest.php
@@ -23,11 +23,17 @@ class GenresTest extends TestCase
     {
         $api = $this->getApiWithMockedHttpAdapter();
 
-        $this->getAdapter()->expects($this->once())
+        $this->getAdapter()->expects($this->at(0))
             ->method('get')
-            ->with($this->getRequest('genre/list'))
+            ->with($this->getRequest('genre/movie/list'))
             ->will($this->returnValue(['genres']))
-        ; // there is no "selective" call, we always lean on the full list
+        ;
+
+        $this->getAdapter()->expects($this->at(1))
+            ->method('get')
+            ->with($this->getRequest('genre/tv/list'))
+            ->will($this->returnValue(['genres']))
+        ; // there is no "selective" call, we always lean on both lists
 
         $api->getGenre(self::GENRE_ID);
     }
@@ -39,11 +45,43 @@ class GenresTest extends TestCase
     {
         $api = $this->getApiWithMockedHttpAdapter();
 
-        $this->getAdapter()->expects($this->once())
+        $this->getAdapter()->expects($this->at(0))
             ->method('get')
-            ->with($this->getRequest('genre/list'));
+            ->with($this->getRequest('genre/movie/list'));
+
+        $this->getAdapter()->expects($this->at(1))
+            ->method('get')
+            ->with($this->getRequest('genre/tv/list'));
 
         $api->getGenres();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetMovieGenres()
+    {
+        $api = $this->getApiWithMockedHttpAdapter();
+
+        $this->getAdapter()->expects($this->once())
+            ->method('get')
+            ->with($this->getRequest('genre/movie/list'));
+
+        $api->getMovieGenres();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetTvGenres()
+    {
+        $api = $this->getApiWithMockedHttpAdapter();
+
+        $this->getAdapter()->expects($this->once())
+            ->method('get')
+            ->with($this->getRequest('genre/tv/list'));
+
+        $api->getTvGenres();
     }
 
     /**

--- a/test/Tmdb/Tests/Repository/GenreRepositoryTest.php
+++ b/test/Tmdb/Tests/Repository/GenreRepositoryTest.php
@@ -23,9 +23,14 @@ class GenreRepositoryTest extends TestCase
     {
         $repository = $this->getRepositoryWithMockedHttpAdapter();
 
-        $this->getAdapter()->expects($this->once())
+        $this->getAdapter()->expects($this->at(0))
             ->method('get')
-            ->with($this->getRequest('genre/list', []))
+            ->with($this->getRequest('genre/movie/list', []))
+        ;
+
+        $this->getAdapter()->expects($this->at(1))
+            ->method('get')
+            ->with($this->getRequest('genre/tv/list', []))
         ;
 
         $repository->load(self::GENRE_ID);
@@ -38,12 +43,47 @@ class GenreRepositoryTest extends TestCase
     {
         $repository = $this->getRepositoryWithMockedHttpAdapter();
 
-        $this->getAdapter()->expects($this->once())
+        $this->getAdapter()->expects($this->at(0))
             ->method('get')
-            ->with($this->getRequest('genre/list', []))
+            ->with($this->getRequest('genre/movie/list', []))
+        ;
+
+        $this->getAdapter()->expects($this->at(1))
+            ->method('get')
+            ->with($this->getRequest('genre/tv/list', []))
         ;
 
         $repository->loadCollection();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldLoadMovieCollection()
+    {
+        $repository = $this->getRepositoryWithMockedHttpAdapter();
+
+        $this->getAdapter()->expects($this->once())
+            ->method('get')
+            ->with($this->getRequest('genre/movie/list', []))
+        ;
+
+        $repository->loadMovieCollection();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldLoadTvCollection()
+    {
+        $repository = $this->getRepositoryWithMockedHttpAdapter();
+
+        $this->getAdapter()->expects($this->once())
+            ->method('get')
+            ->with($this->getRequest('genre/tv/list', []))
+        ;
+
+        $repository->loadTvCollection();
     }
 
     /**


### PR DESCRIPTION
I encountered two new endpoints for genres while trying to import genres into my project. They have split the available genres between movies and TV shows. This commit allows for these two new endpoints to be accessed.

http://docs.themoviedb.apiary.io/#reference/genres/genremovielist/get
http://docs.themoviedb.apiary.io/#reference/genres/genretvlist/get