### PR TITLE
Throws NullException for response codes of 500

### DIFF
--- a/lib/Tmdb/Exception/TmdbApiException.php
+++ b/lib/Tmdb/Exception/TmdbApiException.php
@@ -68,10 +68,10 @@ class TmdbApiException extends \Exception
     /**
      * Create the exception
      *
-     * @param int $code
-     * @param string $message
-     * @param Request|null $request
-     * @param Response|null $response
+     * @param int             $code
+     * @param string          $message
+     * @param Request|null    $request
+     * @param Response|null   $response
      * @param \Exception|null $previous
      */
     public function __construct($code, $message, $request = null, $response = null, \Exception $previous = null)

--- a/lib/Tmdb/Exception/TmdbApiException.php
+++ b/lib/Tmdb/Exception/TmdbApiException.php
@@ -56,16 +56,6 @@ class TmdbApiException extends \Exception
     const STATUS_RESOURCE_NOT_FOUND = 34;
 
     /**
-     * @var int
-     */
-    protected $code;
-
-    /**
-     * @var string
-     */
-    protected $message;
-
-    /**
      * @var Request
      */
     protected $request;
@@ -78,15 +68,16 @@ class TmdbApiException extends \Exception
     /**
      * Create the exception
      *
-     * @param string        $message
-     * @param int           $code
-     * @param Request|null  $request
+     * @param int $code
+     * @param string $message
+     * @param Request|null $request
      * @param Response|null $response
+     * @param \Exception|null $previous
      */
-    public function __construct($code, $message, $request = null, $response = null)
+    public function __construct($code, $message, $request = null, $response = null, \Exception $previous = null)
     {
-        $this->code     = $code;
-        $this->message  = $message;
+        parent::__construct($message, $code, $previous);
+
         $this->request  = $request;
         $this->response = $response;
     }

--- a/lib/Tmdb/HttpClient/Adapter/AbstractAdapter.php
+++ b/lib/Tmdb/HttpClient/Adapter/AbstractAdapter.php
@@ -34,7 +34,7 @@ abstract class AbstractAdapter implements AdapterInterface
         $errors = json_decode((string) $response->getBody());
 
         return new TmdbApiException(
-            isset($errors->status_code) ? $errors->status_code : -1,
+            isset($errors->status_code) ? $errors->status_code : $response->getCode(),
             isset($errors->status_message) ? $errors->status_message : null,
             $request,
             $response,

--- a/lib/Tmdb/HttpClient/Adapter/AbstractAdapter.php
+++ b/lib/Tmdb/HttpClient/Adapter/AbstractAdapter.php
@@ -24,9 +24,9 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Create the unified exception to throw
      *
-     * @param  Request $request
-     * @param  Response $response
-     * @param \Exception $previous
+     * @param  Request          $request
+     * @param  Response         $response
+     * @param \Exception        $previous
      * @return TmdbApiException
      */
     protected function createApiException(Request $request, Response $response, \Exception $previous= null)

--- a/lib/Tmdb/HttpClient/Adapter/AbstractAdapter.php
+++ b/lib/Tmdb/HttpClient/Adapter/AbstractAdapter.php
@@ -24,19 +24,21 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Create the unified exception to throw
      *
-     * @param  Request          $request
-     * @param  Response         $response
+     * @param  Request $request
+     * @param  Response $response
+     * @param \Exception $previous
      * @return TmdbApiException
      */
-    protected function createApiException(Request $request, Response $response)
+    protected function createApiException(Request $request, Response $response, \Exception $previous= null)
     {
         $errors = json_decode((string) $response->getBody());
 
         return new TmdbApiException(
-            $errors->status_code,
-            $errors->status_message,
+            isset($errors->status_code) ? $errors->status_code : -1,
+            isset($errors->status_message) ? $errors->status_message : null,
             $request,
-            $response
+            $response,
+            $previous
         );
     }
 }

--- a/lib/Tmdb/HttpClient/Adapter/GuzzleAdapter.php
+++ b/lib/Tmdb/HttpClient/Adapter/GuzzleAdapter.php
@@ -119,8 +119,14 @@ class GuzzleAdapter extends AbstractAdapter
      */
     protected function handleRequestException(Request $request, RequestException $previousException)
     {
-        if (null !== $previousException && null == $previousException->getResponse()) {
-            throw new NullResponseException($this->request, $previousException);
+        if (null !== $previousException) {
+            $response = $previousException->getResponse();
+            if(null == $response) {
+                throw new NullResponseException($this->request, $previousException);
+            }
+            if($response->getStatusCode() >= 500 && $response->getStatusCode() <= 599) {
+                throw new NullResponseException($this->request, $previousException);
+            }
         }
 
         throw $this->createApiException(

--- a/test/Tmdb/Tests/HttpClient/Adapter/GuzzleAdapterTest.php
+++ b/test/Tmdb/Tests/HttpClient/Adapter/GuzzleAdapterTest.php
@@ -299,6 +299,29 @@ class GuzzleAdapterTest extends TestCase
     }
 
     /**
+     * @expectedException \Tmdb\Exception\NullResponseException
+     * @test
+     */
+    public function shouldThrowExceptionForServerError()
+    {
+        $client = $this->getMock('GuzzleHttp\ClientInterface');
+
+        $client->expects($this->once())
+            ->method('get')
+            ->will($this->throwException(
+                new RequestException(
+                    '500',
+                    new \GuzzleHttp\Message\Request('get', '/'),
+                    new \GuzzleHttp\Message\Response(500, [], Stream::factory('<html><body>Internal Server Error</body></html>'))
+                )
+            ))
+        ;
+
+        $adapter = new GuzzleAdapter($client);
+        $adapter->get(new Request());
+    }
+
+    /**
      * @test
      */
     public function shouldFormatMessageForAnGuzzleHttpRequestException()


### PR DESCRIPTION
Closes #118 

- `AbstractAdapter` will no longer fail for unexpected body content.
- `NullException` error is now thrown for all 500 response codes. (these response contain HTML body, but no JSON). So I figure `NullException` was more consistent than using `TmdbApiException`
- Adds unit test for server 500 errors.