### PR TITLE
Remove urlencode in search API to prevent double encoding

### DIFF
--- a/lib/Tmdb/Api/Search.php
+++ b/lib/Tmdb/Api/Search.php
@@ -30,7 +30,7 @@ class Search extends AbstractApi
     public function searchMovies($query, array $parameters = [], array $headers = [])
     {
         return $this->get('search/movie', array_merge($parameters, [
-            'query' => urlencode($query)
+            'query' => $query
         ], $headers));
     }
 
@@ -45,7 +45,7 @@ class Search extends AbstractApi
     public function searchCollection($query, array $parameters = [], array $headers = [])
     {
         return $this->get('search/collection', array_merge($parameters, [
-            'query' => urlencode($query)
+            'query' => $query
         ], $headers));
     }
 
@@ -60,7 +60,7 @@ class Search extends AbstractApi
     public function searchTv($query, array $parameters = [], array $headers = [])
     {
         return $this->get('search/tv', array_merge($parameters, [
-            'query' => urlencode($query)
+            'query' => $query
         ], $headers));
     }
 
@@ -75,7 +75,7 @@ class Search extends AbstractApi
     public function searchPersons($query, array $parameters = [], array $headers = [])
     {
         return $this->get('search/person', array_merge($parameters, [
-            'query' => urlencode($query)
+            'query' => $query
         ], $headers));
     }
 
@@ -90,7 +90,7 @@ class Search extends AbstractApi
     public function searchList($query, array $parameters = [], array $headers = [])
     {
         return $this->get('search/list', array_merge($parameters, [
-            'query' => urlencode($query)
+            'query' => $query
         ], $headers));
     }
 
@@ -105,7 +105,7 @@ class Search extends AbstractApi
     public function searchCompany($query, array $parameters = [], array $headers = [])
     {
         return $this->get('search/company', array_merge($parameters, [
-            'query' => urlencode($query)
+            'query' => $query
         ], $headers));
     }
 
@@ -120,7 +120,7 @@ class Search extends AbstractApi
     public function searchKeyword($query, array $parameters = [], array $headers = [])
     {
         return $this->get('search/keyword', array_merge($parameters, [
-            'query' => urlencode($query)
+            'query' => $query
         ], $headers));
     }
 
@@ -138,7 +138,7 @@ class Search extends AbstractApi
     public function searchMulti($query, array $parameters = [], array $headers = [])
     {
         return $this->get('search/multi', array_merge($parameters, [
-            'query' => urlencode($query)
+            'query' => $query
         ], $headers));
     }
 }

--- a/test/Tmdb/Tests/Api/SearchTest.php
+++ b/test/Tmdb/Tests/Api/SearchTest.php
@@ -31,7 +31,7 @@ class SearchTest extends TestCase
 
         $this->getAdapter()->expects($this->once())
             ->method('get')
-            ->with($this->getRequest('search/movie', ['query' => urlencode(self::QUERY_MOVIE)]))
+            ->with($this->getRequest('search/movie', ['query' => self::QUERY_MOVIE]))
         ;
 
         $api->searchMovies(self::QUERY_MOVIE);
@@ -46,7 +46,7 @@ class SearchTest extends TestCase
 
         $this->getAdapter()->expects($this->once())
             ->method('get')
-            ->with($this->getRequest('search/collection', ['query' => urlencode(self::QUERY_COLLECTION)]))
+            ->with($this->getRequest('search/collection', ['query' => self::QUERY_COLLECTION]))
         ;
 
         $api->searchCollection(self::QUERY_COLLECTION);
@@ -61,7 +61,7 @@ class SearchTest extends TestCase
 
         $this->getAdapter()->expects($this->once())
             ->method('get')
-            ->with($this->getRequest('search/tv', ['query' => urlencode(self::QUERY_TV)]))
+            ->with($this->getRequest('search/tv', ['query' => self::QUERY_TV]))
         ;
 
         $api->searchTv(self::QUERY_TV);
@@ -76,7 +76,7 @@ class SearchTest extends TestCase
 
         $this->getAdapter()->expects($this->once())
             ->method('get')
-            ->with($this->getRequest('search/person', ['query' => urlencode(self::QUERY_PERSON)]))
+            ->with($this->getRequest('search/person', ['query' => self::QUERY_PERSON]))
         ;
 
         $api->searchPersons(self::QUERY_PERSON);
@@ -91,7 +91,7 @@ class SearchTest extends TestCase
 
         $this->getAdapter()->expects($this->once())
             ->method('get')
-            ->with($this->getRequest('search/list', ['query' => urlencode(self::QUERY_LIST)]))
+            ->with($this->getRequest('search/list', ['query' => self::QUERY_LIST]))
         ;
 
         $api->searchList(self::QUERY_LIST);
@@ -106,7 +106,7 @@ class SearchTest extends TestCase
 
         $this->getAdapter()->expects($this->once())
             ->method('get')
-            ->with($this->getRequest('search/company', ['query' => urlencode(self::QUERY_COMPANY)]))
+            ->with($this->getRequest('search/company', ['query' => self::QUERY_COMPANY]))
         ;
 
         $api->searchCompany(self::QUERY_COMPANY);
@@ -121,7 +121,7 @@ class SearchTest extends TestCase
 
         $this->getAdapter()->expects($this->once())
             ->method('get')
-            ->with($this->getRequest('search/keyword', ['query' => urlencode(self::QUERY_KEYWORD)]))
+            ->with($this->getRequest('search/keyword', ['query' => self::QUERY_KEYWORD]))
         ;
 
         $api->searchKeyword(self::QUERY_KEYWORD);
@@ -136,7 +136,7 @@ class SearchTest extends TestCase
 
         $this->getAdapter()->expects($this->once())
             ->method('get')
-            ->with($this->getRequest('search/multi', ['query' => urlencode(self::QUERY_KEYWORD)]))
+            ->with($this->getRequest('search/multi', ['query' => self::QUERY_KEYWORD]))
         ;
 
         $api->searchMulti(self::QUERY_KEYWORD);

--- a/test/Tmdb/Tests/Repository/SearchRepositoryTest.php
+++ b/test/Tmdb/Tests/Repository/SearchRepositoryTest.php
@@ -47,7 +47,7 @@ class SearchRepositoryTest extends TestCase
             ->method('get')
             ->with($this->getRequest(
                 'search/movie',
-                ['page' => 1, 'query' => urlencode(self::MOVIE_QUERY)]
+                ['page' => 1, 'query' => self::MOVIE_QUERY]
             ))
         ;
 
@@ -68,7 +68,7 @@ class SearchRepositoryTest extends TestCase
             ->method('get')
             ->with($this->getRequest(
                 'search/collection',
-                ['page' => 1, 'query' => urlencode(self::COLLECTION_QUERY)]
+                ['page' => 1, 'query' => self::COLLECTION_QUERY]
             ))
         ;
 
@@ -89,7 +89,7 @@ class SearchRepositoryTest extends TestCase
             ->method('get')
             ->with($this->getRequest(
                 'search/tv',
-                ['page' => 1, 'query' => urlencode(self::TV_QUERY)]
+                ['page' => 1, 'query' => self::TV_QUERY]
             ))
         ;
 
@@ -110,7 +110,7 @@ class SearchRepositoryTest extends TestCase
             ->method('get')
             ->with($this->getRequest(
                 'search/person',
-                ['page' => 1, 'query' => urlencode(self::PERSON_QUERY)]
+                ['page' => 1, 'query' => self::PERSON_QUERY]
             ))
         ;
 
@@ -131,7 +131,7 @@ class SearchRepositoryTest extends TestCase
             ->method('get')
             ->with($this->getRequest(
                 'search/list',
-                ['page' => 1, 'query' => urlencode(self::LIST_QUERY)]
+                ['page' => 1, 'query' => self::LIST_QUERY]
             ))
         ;
 
@@ -152,7 +152,7 @@ class SearchRepositoryTest extends TestCase
             ->method('get')
             ->with($this->getRequest(
                 'search/company',
-                ['page' => 1, 'query' => urlencode(self::COMPANY_QUERY)]
+                ['page' => 1, 'query' => self::COMPANY_QUERY]
             ))
         ;
 
@@ -173,7 +173,7 @@ class SearchRepositoryTest extends TestCase
             ->method('get')
             ->with($this->getRequest(
                 'search/keyword',
-                ['page' => 1, 'query' => urlencode(self::KEYWORD_QUERY)]
+                ['page' => 1, 'query' => self::KEYWORD_QUERY]
             ))
         ;
 
@@ -194,7 +194,7 @@ class SearchRepositoryTest extends TestCase
             ->method('get')
             ->with($this->getRequest(
                 'search/multi',
-                ['page' => 1, 'query' => urlencode(self::MULTI_QUERY)]
+                ['page' => 1, 'query' => self::MULTI_QUERY]
             ))
             ->will($this->returnValue(new Response(200, json_encode([
                 'page' => 1,
@@ -222,7 +222,7 @@ class SearchRepositoryTest extends TestCase
             ->method('get')
             ->with($this->getRequest(
                 'search/multi',
-                ['page' => 1, 'query' => urlencode(self::MULTI_QUERY)]
+                ['page' => 1, 'query' => self::MULTI_QUERY]
             ))
             ->will($this->returnValue(null))
         ;


### PR DESCRIPTION
Hello,

Testing the search API, I discovered that the URL encoding happened twice: on TMDB API side first, and then Guzzle does it again.

This is not an issue in many cases, but if you start dealing with accents it makes TMDB unable to return any result.

I have forked and fixed the issue on my side. Thought it could be of an interest to you.

