### PR TITLE
Fixed Episode and Season Repositories

### DIFF
--- a/lib/Tmdb/Repository/TvEpisodeRepository.php
+++ b/lib/Tmdb/Repository/TvEpisodeRepository.php
@@ -51,11 +51,11 @@ class TvEpisodeRepository extends AbstractRepository
         }
 
         if ($season instanceof Season) {
-            $season = $season->getId();
+            $season = $season->getSeasonNumber();
         }
 
         if ($episode instanceof Tv\Episode) {
-            $episode = $episode->getId();
+            $episode = $episode->getEpisodeNumber();
         }
 
         if (null == $tvShow || null == $season || null == $episode) {

--- a/lib/Tmdb/Repository/TvEpisodeRepository.php
+++ b/lib/Tmdb/Repository/TvEpisodeRepository.php
@@ -104,11 +104,11 @@ class TvEpisodeRepository extends AbstractRepository
         }
 
         if ($season instanceof Season) {
-            $season = $season->getId();
+            $season = $season->getSeasonNumber();
         }
 
         if ($episode instanceof Tv\Episode) {
-            $episode = $episode->getId();
+            $episode = $episode->getEpisodeNumber();
         }
 
         $data = $this->getApi()->getCredits(
@@ -141,11 +141,11 @@ class TvEpisodeRepository extends AbstractRepository
         }
 
         if ($season instanceof Season) {
-            $season = $season->getId();
+            $season = $season->getSeasonNumber();
         }
 
         if ($episode instanceof Tv\Episode) {
-            $episode = $episode->getId();
+            $episode = $episode->getEpisodeNumber();
         }
 
         $data = $this->getApi()->getExternalIds(
@@ -178,11 +178,11 @@ class TvEpisodeRepository extends AbstractRepository
         }
 
         if ($season instanceof Season) {
-            $season = $season->getId();
+            $season = $season->getSeasonNumber();
         }
 
         if ($episode instanceof Tv\Episode) {
-            $episode = $episode->getId();
+            $episode = $episode->getEpisodeNumber();
         }
 
         $data = $this->getApi()->getImages(
@@ -215,11 +215,11 @@ class TvEpisodeRepository extends AbstractRepository
         }
 
         if ($season instanceof Season) {
-            $season = $season->getId();
+            $season = $season->getSeasonNumber();
         }
 
         if ($episode instanceof Tv\Episode) {
-            $episode = $episode->getId();
+            $episode = $episode->getEpisodeNumber();
         }
 
         $data = $this->getApi()->getVideos(
@@ -253,11 +253,11 @@ class TvEpisodeRepository extends AbstractRepository
         }
 
         if ($season instanceof Season) {
-            $season = $season->getId();
+            $season = $season->getSeasonNumber();
         }
 
         if ($episode instanceof Tv\Episode) {
-            $episode = $episode->getId();
+            $episode = $episode->getEpisodeNumber();
         }
 
         return $this->getFactory()->createAccountStates(
@@ -283,11 +283,11 @@ class TvEpisodeRepository extends AbstractRepository
         }
 
         if ($season instanceof Season) {
-            $season = $season->getId();
+            $season = $season->getSeasonNumber();
         }
 
         if ($episode instanceof Tv\Episode) {
-            $episode = $episode->getId();
+            $episode = $episode->getEpisodeNumber();
         }
 
         return $this->getFactory()->createResult(

--- a/lib/Tmdb/Repository/TvEpisodeRepository.php
+++ b/lib/Tmdb/Repository/TvEpisodeRepository.php
@@ -58,7 +58,7 @@ class TvEpisodeRepository extends AbstractRepository
             $episode = $episode->getEpisodeNumber();
         }
 
-        if (null == $tvShow || null == $season || null == $episode) {
+        if (is_null($tvShow) || is_null($season) || is_null($episode) ) {
             throw new RuntimeException('Not all required parameters to load an tv episode are present.');
         }
 

--- a/lib/Tmdb/Repository/TvSeasonRepository.php
+++ b/lib/Tmdb/Repository/TvSeasonRepository.php
@@ -88,7 +88,7 @@ class TvSeasonRepository extends AbstractRepository
         }
 
         if ($season instanceof Season) {
-            $season = $season->getId();
+            $season = $season->getSeasonNumber();
         }
 
         $data   = $this->getApi()->getCredits($tvShow, $season, $this->parseQueryParameters($parameters), $headers);
@@ -113,7 +113,7 @@ class TvSeasonRepository extends AbstractRepository
         }
 
         if ($season instanceof Season) {
-            $season = $season->getId();
+            $season = $season->getSeasonNumber();
         }
 
         $data   = $this->getApi()->getExternalIds($tvShow, $season, $this->parseQueryParameters($parameters), $headers);
@@ -138,7 +138,7 @@ class TvSeasonRepository extends AbstractRepository
         }
 
         if ($season instanceof Season) {
-            $season = $season->getId();
+            $season = $season->getSeasonNumber();
         }
 
         $data   = $this->getApi()->getImages($tvShow, $season, $this->parseQueryParameters($parameters), $headers);
@@ -163,7 +163,7 @@ class TvSeasonRepository extends AbstractRepository
         }
 
         if ($season instanceof Season) {
-            $season = $season->getId();
+            $season = $season->getSeasonNumber();
         }
 
         $data   = $this->getApi()->getVideos($tvShow, $season, $this->parseQueryParameters($parameters), $headers);

--- a/test/Tmdb/Tests/Repository/TvEpisodeRepositoryTest.php
+++ b/test/Tmdb/Tests/Repository/TvEpisodeRepositoryTest.php
@@ -60,9 +60,11 @@ class TvEpisodeRepositoryTest extends TestCase
 
         $season = new Season();
         $season->setId(self::SEASON_ID);
+        $season->setSeasonNumber(self::SEASON_ID);
 
         $episode = new Episode();
         $episode->setId(self::EPISODE_ID);
+        $episode->setEpisodeNumber(self::EPISODE_ID);
 
         $repository->load($tv, $season, $episode);
     }
@@ -86,9 +88,11 @@ class TvEpisodeRepositoryTest extends TestCase
 
         $season = new Season();
         $season->setId(self::SEASON_ID);
+        $season->setSeasonNumber(self::SEASON_ID);
 
         $episode = new Episode();
         $episode->setId(self::EPISODE_ID);
+        $episode->setEpisodeNumber(self::EPISODE_ID);
 
         $repository->getCredits($tv, $season, $episode);
     }
@@ -112,9 +116,11 @@ class TvEpisodeRepositoryTest extends TestCase
 
         $season = new Season();
         $season->setId(self::SEASON_ID);
+        $season->setSeasonNumber(self::SEASON_ID);
 
         $episode = new Episode();
         $episode->setId(self::EPISODE_ID);
+        $episode->setEpisodeNumber(self::EPISODE_ID);
 
         $repository->getExternalIds($tv, $season, $episode);
     }
@@ -138,9 +144,11 @@ class TvEpisodeRepositoryTest extends TestCase
 
         $season = new Season();
         $season->setId(self::SEASON_ID);
+        $season->setSeasonNumber(self::SEASON_ID);
 
         $episode = new Episode();
         $episode->setId(self::EPISODE_ID);
+        $episode->setEpisodeNumber(self::EPISODE_ID);
 
         $repository->getImages($tv, $season, $episode);
     }
@@ -164,9 +172,11 @@ class TvEpisodeRepositoryTest extends TestCase
 
         $season = new Season();
         $season->setId(self::SEASON_ID);
+        $season->setSeasonNumber(self::SEASON_ID);
 
         $episode = new Episode();
         $episode->setId(self::EPISODE_ID);
+        $episode->setEpisodeNumber(self::EPISODE_ID);
 
         $repository->getVideos($tv, $season, $episode);
     }
@@ -179,11 +189,13 @@ class TvEpisodeRepositoryTest extends TestCase
     {
         $repository = $this->getRepositoryWithMockedHttpClient();
 
-        $tv = new Tv();
-        $tv->setId(self::TV_ID);
-
         $season = new Season();
         $season->setId(self::SEASON_ID);
+        $season->setSeasonNumber(self::SEASON_ID);
+
+        $episode = new Episode();
+        $episode->setId(self::EPISODE_ID);
+        $episode->setEpisodeNumber(self::EPISODE_ID);
 
         $repository->load($tv, $season, null);
     }

--- a/test/Tmdb/Tests/Repository/TvEpisodeRepositoryTest.php
+++ b/test/Tmdb/Tests/Repository/TvEpisodeRepositoryTest.php
@@ -19,8 +19,8 @@ use Tmdb\Model\Tv;
 class TvEpisodeRepositoryTest extends TestCase
 {
     const TV_ID      = 3572;
-    const SEASON_ID  = 1;
-    const EPISODE_ID = 1;
+    const SEASON_NUMBER  = 1;
+    const EPISODE_NUMBER = 1;
 
     /**
      * @test
@@ -59,12 +59,10 @@ class TvEpisodeRepositoryTest extends TestCase
         $tv->setId(self::TV_ID);
 
         $season = new Season();
-        $season->setId(self::SEASON_ID);
-        $season->setSeasonNumber(self::SEASON_ID);
+        $season->setSeasonNumber(self::SEASON_NUMBER);
 
         $episode = new Episode();
-        $episode->setId(self::EPISODE_ID);
-        $episode->setEpisodeNumber(self::EPISODE_ID);
+        $episode->setEpisodeNumber(self::EPISODE_NUMBER);
 
         $repository->load($tv, $season, $episode);
     }
@@ -87,12 +85,10 @@ class TvEpisodeRepositoryTest extends TestCase
         $tv->setId(self::TV_ID);
 
         $season = new Season();
-        $season->setId(self::SEASON_ID);
-        $season->setSeasonNumber(self::SEASON_ID);
+        $season->setSeasonNumber(self::SEASON_NUMBER);
 
         $episode = new Episode();
-        $episode->setId(self::EPISODE_ID);
-        $episode->setEpisodeNumber(self::EPISODE_ID);
+        $episode->setEpisodeNumber(self::EPISODE_NUMBER);
 
         $repository->getCredits($tv, $season, $episode);
     }
@@ -115,12 +111,10 @@ class TvEpisodeRepositoryTest extends TestCase
         $tv->setId(self::TV_ID);
 
         $season = new Season();
-        $season->setId(self::SEASON_ID);
-        $season->setSeasonNumber(self::SEASON_ID);
+        $season->setSeasonNumber(self::SEASON_NUMBER);
 
         $episode = new Episode();
-        $episode->setId(self::EPISODE_ID);
-        $episode->setEpisodeNumber(self::EPISODE_ID);
+        $episode->setEpisodeNumber(self::EPISODE_NUMBER);
 
         $repository->getExternalIds($tv, $season, $episode);
     }
@@ -143,12 +137,10 @@ class TvEpisodeRepositoryTest extends TestCase
         $tv->setId(self::TV_ID);
 
         $season = new Season();
-        $season->setId(self::SEASON_ID);
-        $season->setSeasonNumber(self::SEASON_ID);
+        $season->setSeasonNumber(self::SEASON_NUMBER);
 
         $episode = new Episode();
-        $episode->setId(self::EPISODE_ID);
-        $episode->setEpisodeNumber(self::EPISODE_ID);
+        $episode->setEpisodeNumber(self::EPISODE_NUMBER);
 
         $repository->getImages($tv, $season, $episode);
     }
@@ -171,12 +163,10 @@ class TvEpisodeRepositoryTest extends TestCase
         $tv->setId(self::TV_ID);
 
         $season = new Season();
-        $season->setId(self::SEASON_ID);
-        $season->setSeasonNumber(self::SEASON_ID);
+        $season->setSeasonNumber(self::SEASON_NUMBER);
 
         $episode = new Episode();
-        $episode->setId(self::EPISODE_ID);
-        $episode->setEpisodeNumber(self::EPISODE_ID);
+        $episode->setEpisodeNumber(self::EPISODE_NUMBER);
 
         $repository->getVideos($tv, $season, $episode);
     }
@@ -190,12 +180,10 @@ class TvEpisodeRepositoryTest extends TestCase
         $repository = $this->getRepositoryWithMockedHttpClient();
 
         $season = new Season();
-        $season->setId(self::SEASON_ID);
-        $season->setSeasonNumber(self::SEASON_ID);
+        $season->setSeasonNumber(self::SEASON_NUMBER);
 
         $episode = new Episode();
-        $episode->setId(self::EPISODE_ID);
-        $episode->setEpisodeNumber(self::EPISODE_ID);
+        $episode->setEpisodeNumber(self::EPISODE_NUMBER);
 
         $repository->load($tv, $season, null);
     }

--- a/test/Tmdb/Tests/Repository/TvEpisodeRepositoryTest.php
+++ b/test/Tmdb/Tests/Repository/TvEpisodeRepositoryTest.php
@@ -32,12 +32,12 @@ class TvEpisodeRepositoryTest extends TestCase
         $this->getAdapter()->expects($this->once())
             ->method('get')
             ->with($this->getRequest(
-                'https://api.themoviedb.org/3/tv/' . self::TV_ID . '/season/' . self::SEASON_ID . '/episode/' . self::EPISODE_ID,
+                'https://api.themoviedb.org/3/tv/' . self::TV_ID . '/season/' . self::SEASON_NUMBER . '/episode/' . self::EPISODE_NUMBER,
                 ['append_to_response' => 'credits,external_ids,images,changes,videos']
             ))
         ;
 
-        $repository->load(self::TV_ID, self::SEASON_ID, self::EPISODE_ID);
+        $repository->load(self::TV_ID, self::SEASON_NUMBER, self::EPISODE_NUMBER);
     }
 
     /**
@@ -50,7 +50,7 @@ class TvEpisodeRepositoryTest extends TestCase
         $this->getAdapter()->expects($this->once())
             ->method('get')
             ->with($this->getRequest(
-                'https://api.themoviedb.org/3/tv/' . self::TV_ID . '/season/' . self::SEASON_ID . '/episode/' . self::EPISODE_ID,
+                'https://api.themoviedb.org/3/tv/' . self::TV_ID . '/season/' . self::SEASON_NUMBER . '/episode/' . self::EPISODE_NUMBER,
                 ['append_to_response' => 'credits,external_ids,images,changes,videos']
             ))
         ;
@@ -77,7 +77,7 @@ class TvEpisodeRepositoryTest extends TestCase
         $this->getAdapter()->expects($this->once())
             ->method('get')
             ->with($this->getRequest(
-                'https://api.themoviedb.org/3/tv/' . self::TV_ID . '/season/' . self::SEASON_ID . '/episode/' . self::EPISODE_ID . '/credits'
+                'https://api.themoviedb.org/3/tv/' . self::TV_ID . '/season/' . self::SEASON_NUMBER . '/episode/' . self::EPISODE_NUMBER . '/credits'
             ))
         ;
 
@@ -103,7 +103,7 @@ class TvEpisodeRepositoryTest extends TestCase
         $this->getAdapter()->expects($this->once())
             ->method('get')
             ->with($this->getRequest(
-                'https://api.themoviedb.org/3/tv/' . self::TV_ID . '/season/' . self::SEASON_ID . '/episode/' . self::EPISODE_ID . '/external_ids'
+                'https://api.themoviedb.org/3/tv/' . self::TV_ID . '/season/' . self::SEASON_NUMBER . '/episode/' . self::EPISODE_NUMBER . '/external_ids'
             ))
         ;
 
@@ -129,7 +129,7 @@ class TvEpisodeRepositoryTest extends TestCase
         $this->getAdapter()->expects($this->once())
             ->method('get')
             ->with($this->getRequest(
-                'https://api.themoviedb.org/3/tv/' . self::TV_ID . '/season/' . self::SEASON_ID . '/episode/' . self::EPISODE_ID . '/images'
+                'https://api.themoviedb.org/3/tv/' . self::TV_ID . '/season/' . self::SEASON_NUMBER . '/episode/' . self::EPISODE_NUMBER . '/images'
             ))
         ;
 
@@ -155,7 +155,7 @@ class TvEpisodeRepositoryTest extends TestCase
         $this->getAdapter()->expects($this->once())
             ->method('get')
             ->with($this->getRequest(
-                'https://api.themoviedb.org/3/tv/' . self::TV_ID . '/season/' . self::SEASON_ID . '/episode/' . self::EPISODE_ID . '/videos'
+                'https://api.themoviedb.org/3/tv/' . self::TV_ID . '/season/' . self::SEASON_NUMBER . '/episode/' . self::EPISODE_NUMBER . '/videos'
             ))
         ;
 

--- a/test/Tmdb/Tests/Repository/TvEpisodeRepositoryTest.php
+++ b/test/Tmdb/Tests/Repository/TvEpisodeRepositoryTest.php
@@ -179,11 +179,11 @@ class TvEpisodeRepositoryTest extends TestCase
     {
         $repository = $this->getRepositoryWithMockedHttpClient();
 
+        $tv = new Tv();
+        $tv->setId(self::TV_ID);
+
         $season = new Season();
         $season->setSeasonNumber(self::SEASON_NUMBER);
-
-        $episode = new Episode();
-        $episode->setEpisodeNumber(self::EPISODE_NUMBER);
 
         $repository->load($tv, $season, null);
     }

--- a/test/Tmdb/Tests/Repository/TvSeasonRepositoryTest.php
+++ b/test/Tmdb/Tests/Repository/TvSeasonRepositoryTest.php
@@ -79,7 +79,7 @@ class TvSeasonRepositoryTest extends TestCase
         $tv->setId(self::TV_ID);
 
         $season = new Tv\Season();
-        $season->setId(self::SEASON_NUMBER);
+        $season->setSeasonNumber(self::SEASON_NUMBER);
 
         $repository->getCredits($tv, $season);
     }
@@ -102,7 +102,7 @@ class TvSeasonRepositoryTest extends TestCase
         $tv->setId(self::TV_ID);
 
         $season = new Tv\Season();
-        $season->setId(self::SEASON_NUMBER);
+        $season->setSeasonNumber(self::SEASON_NUMBER);
 
         $repository->getExternalIds($tv, $season);
     }
@@ -125,7 +125,7 @@ class TvSeasonRepositoryTest extends TestCase
         $tv->setId(self::TV_ID);
 
         $season = new Tv\Season();
-        $season->setId(self::SEASON_NUMBER);
+        $season->setSeasonNumber(self::SEASON_NUMBER);
 
         $repository->getImages($tv, $season);
     }
@@ -148,7 +148,7 @@ class TvSeasonRepositoryTest extends TestCase
         $tv->setId(self::TV_ID);
 
         $season = new Tv\Season();
-        $season->setId(self::SEASON_NUMBER);
+        $season->setSeasonNumber(self::SEASON_NUMBER);
 
         $repository->getVideos($tv, $season);
     }


### PR DESCRIPTION
Episode and Season API use the Season Number and Episode Number and not their id to fetch data. 

Also changed the check with the is_null function in the load function as there is a chance
that there is a Season 0 for a TV Show. When the Season is 0 then the
$season == null returns true.