### PR TITLE
TvSeasonRepository not loading Season with number 0

### DIFF
--- a/lib/Tmdb/Repository/TvSeasonRepository.php
+++ b/lib/Tmdb/Repository/TvSeasonRepository.php
@@ -49,7 +49,7 @@ class TvSeasonRepository extends AbstractRepository
             $season = $season->getSeasonNumber();
         }
 
-        if (null === $tvShow || null === $season) {
+        if (is_null($tvShow) || is_null($season)) {
             throw new RuntimeException('Not all required parameters to load an tv season are present.');
         }
 


### PR DESCRIPTION
There was an issue with the null check on TvSeasonRepository->load().
PHP casts a season 0 (for pilots or special seasons) to null