### PR TITLE
Fixed syntax errors in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ $client = new \Tmdb\Client($token, [
     'log' => [
         'enabled' => true,
         'path'    => '/var/www/php-tmdb-api.log'
-        )
     ]
 ]);
 ```
@@ -160,7 +159,6 @@ $client = new \Tmdb\Client($token, [
     'log' => [
         'enabled' => true,
         'handler' => new \Monolog\Handler\ChromePHPHandler()
-        )
     ]
 ]);
 ```


### PR DESCRIPTION
@wtfzdotnet @MarkRedeman This ")" is not needed, right?