### PR TITLE
Update example for using the ArrayCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,12 @@ $client = new \Tmdb\Client($token, [
     Or replace the whole implementation with another CacheStorage of Doctrine:
     
 ```php
+use Doctrine\Common\Cache\ArrayCache;
+use Kevinrob\GuzzleCache\Storage\DoctrineCacheStorage;
+
 $client = new \Tmdb\Client($token, [
         'cache' => [
-            'handler' => new \Doctrine\Common\Cache\ArrayCache()
+            'handler' => new DoctrineCacheStorage(new ArrayCache())
         ]
     ]
 );


### PR DESCRIPTION
The middleware has changed with 2.1 where Guzzle 6 is using `guzzle-cache-middleware` now. I was getting an error using the `ArrayCache()` example, but wrapping the object in `new DoctrineCacheStorage(new ArrayCache())` fixed the issue.

The new cache objects have to have the interface from the `guzzle-cache-middleware` project.