### PR TITLE
Add properties of tv shows to MovieCredit and name it more generic

### DIFF
--- a/lib/Tmdb/Factory/PeopleFactory.php
+++ b/lib/Tmdb/Factory/PeopleFactory.php
@@ -118,7 +118,7 @@ class PeopleFactory extends AbstractFactory
                 if (array_key_exists('cast', $data[$type])) {
                     $cast = $this->createCustomCollection(
                         $data[$type]['cast'],
-                        new Person\MovieCredit(),
+                        new Person\Credit(),
                         new People\Cast()
                     );
 
@@ -132,7 +132,7 @@ class PeopleFactory extends AbstractFactory
                 if (array_key_exists('crew', $data[$type])) {
                     $crew = $this->createCustomCollection(
                         $data[$type]['crew'],
-                        new Person\MovieCredit(),
+                        new Person\Credit(),
                         new People\Crew()
                     );
 

--- a/lib/Tmdb/Model/Person/Credit.php
+++ b/lib/Tmdb/Model/Person/Credit.php
@@ -19,7 +19,7 @@ use Tmdb\Model\Image\PosterImage;
  * Class MovieCredit
  * @package Tmdb\Model\Person
  */
-class MovieCredit extends AbstractModel
+class Credit extends AbstractModel
 {
     /**
      * @var bool
@@ -66,6 +66,41 @@ class MovieCredit extends AbstractModel
      */
     private $posterImage;
 
+    /**
+     * @var string
+     */
+    private $job;
+
+    /**
+     * @var string
+     */
+    private $department;
+
+    /**
+     * @var string
+     */
+    private $mediaType;
+
+    /**
+     * @var string
+     */
+    private $originalName;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var int
+     */
+    private $episodeCount;
+
+    /**
+     * @var mixed
+     */
+    private $firstAirDate;
+
     public static $properties = array(
         'adult',
         'character',
@@ -74,7 +109,14 @@ class MovieCredit extends AbstractModel
         'original_title',
         'poster_path',
         'release_date',
-        'title'
+        'title',
+        'job',
+        'department',
+        'original_name',
+        'name',
+        'media_type',
+        'episode_count',
+        'first_air_date'
     );
 
     /**
@@ -250,5 +292,138 @@ class MovieCredit extends AbstractModel
     public function getTitle()
     {
         return $this->title;
+    }
+
+    /**
+     * @param  string $job
+     * @return $this
+     */
+    public function setJob($job)
+    {
+        $this->job = $job;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getJob()
+    {
+        return $this->job;
+    }
+
+    /**
+     * @param  string $department
+     * @return $this
+     */
+    public function setDepartment($department)
+    {
+        $this->department = $department;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDepartment()
+    {
+        return $this->department;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOriginalName()
+    {
+        return $this->originalName;
+    }
+
+    /**
+     * @param string $originalName
+     * @return $this
+     */
+    public function setOriginalName($originalName)
+    {
+        $this->originalName = $originalName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return $this
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMediaType()
+    {
+        return $this->mediaType;
+    }
+
+    /**
+     * @param string $mediaType
+     * @return $this
+     */
+    public function setMediaType($mediaType)
+    {
+        $this->mediaType = $mediaType;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getEpisodeCount()
+    {
+        return $this->episodeCount;
+    }
+
+    /**
+     * @param int $episodeCount
+     * @return $this
+     */
+    public function setEpisodeCount($episodeCount)
+    {
+        $this->episodeCount = $episodeCount;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFirstAirDate()
+    {
+        return $this->firstAirDate;
+    }
+
+    /**
+     * @param mixed $firstAirDate
+     * @return $this
+     */
+    public function setFirstAirDate($firstAirDate)
+    {
+        $this->firstAirDate = $firstAirDate;
+
+        return $this;
     }
 }


### PR DESCRIPTION
I had the Problem, when loaded a person, the credits would not be filled up correctly.

especially the tv show data can not be set on the credit:
![image](https://cloud.githubusercontent.com/assets/4414498/21788739/a317084e-d6d0-11e6-9c4b-9d803be258e9.png)

hope this PR helps.