### PR TITLE
Fixes issue with logger level resolver name collision

### DIFF
--- a/lib/Tmdb/HttpClient/HttpClient.php
+++ b/lib/Tmdb/HttpClient/HttpClient.php
@@ -486,7 +486,9 @@ class HttpClient
             if ($this->getAdapter() instanceof GuzzleAdapter) {
                 $middleware = new \Concat\Http\Middleware\Logger($logger);
                 $middleware->setRequestLoggingEnabled(true);
-                $middleware->setLogLevel(LogLevel::DEBUG);
+                $middleware->setLogLevel(function($response) {
+                    return LogLevel::DEBUG;
+                });
 
                 $this->getAdapter()->getClient()->getConfig('handler')->push(
                     $middleware,


### PR DESCRIPTION
As of https://github.com/rtheunissen/guzzle-log-middleware/issues/3 fixes https://github.com/php-tmdb/laravel/issues/31