### PR TITLE
Add phpunit 4.8 to test branch '2.0' on php <5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,13 @@ matrix:
       env: [SF_EVT_DISPATCHER_VERSION="2.8.*", SF_OPT_RESOLVER_VERSION="2.8.*"]
     - php: 5.6
       env: [SF_EVT_DISPATCHER_VERSION="3.0.*", SF_OPT_RESOLVER_VERSION="3.0.*"]
+    - php: 5.6
+      env: [SF_EVT_DISPATCHER_VERSION="3.1.*", SF_OPT_RESOLVER_VERSION="3.1.*"]
+    - php: 5.6
+      env: [SF_EVT_DISPATCHER_VERSION="3.2.*", SF_OPT_RESOLVER_VERSION="3.2.*"]
+    - php: 5.6
+      env: [SF_EVT_DISPATCHER_VERSION="^3.3", SF_OPT_RESOLVER_VERSION="^3.3"]
+
     - php: 7.0
       env: [SF_EVT_DISPATCHER_VERSION="2.4.*", SF_OPT_RESOLVER_VERSION="2.6.*"]
     - php: 7.0
@@ -33,6 +40,28 @@ matrix:
       env: [SF_EVT_DISPATCHER_VERSION="2.8.*", SF_OPT_RESOLVER_VERSION="2.8.*"]
     - php: 7.0
       env: [SF_EVT_DISPATCHER_VERSION="3.0.*", SF_OPT_RESOLVER_VERSION="3.0.*"]
+    - php: 7.0
+      env: [SF_EVT_DISPATCHER_VERSION="3.1.*", SF_OPT_RESOLVER_VERSION="3.1.*"]
+    - php: 7.0
+      env: [SF_EVT_DISPATCHER_VERSION="3.2.*", SF_OPT_RESOLVER_VERSION="3.2.*"]
+    - php: 7.0
+      env: [SF_EVT_DISPATCHER_VERSION="^3.3", SF_OPT_RESOLVER_VERSION="^3.3"]
+
+    - php: 7.1
+      env: [SF_EVT_DISPATCHER_VERSION="2.4.*", SF_OPT_RESOLVER_VERSION="2.6.*"]
+    - php: 7.1
+      env: [SF_EVT_DISPATCHER_VERSION="2.7.*", SF_OPT_RESOLVER_VERSION="2.7.*"]
+    - php: 7.1
+      env: [SF_EVT_DISPATCHER_VERSION="2.8.*", SF_OPT_RESOLVER_VERSION="2.8.*"]
+    - php: 7.1
+      env: [SF_EVT_DISPATCHER_VERSION="3.0.*", SF_OPT_RESOLVER_VERSION="3.0.*"]
+    - php: 7.1
+      env: [SF_EVT_DISPATCHER_VERSION="3.1.*", SF_OPT_RESOLVER_VERSION="3.1.*"]
+    - php: 7.1
+      env: [SF_EVT_DISPATCHER_VERSION="3.2.*", SF_OPT_RESOLVER_VERSION="3.2.*"]
+    - php: 7.1
+      env: [SF_EVT_DISPATCHER_VERSION="^3.3", SF_OPT_RESOLVER_VERSION="^3.3"]
+
   allow_failures:
     - php: nightly
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - if [ "$SF_OPT_RESOLVER_VERSION" != "" ];   then composer require --no-update symfony/options-resolver:${SF_OPT_RESOLVER_VERSION};   fi;
   - composer install --no-interaction --prefer-source --dev
 
-script: phpunit --coverage-text --coverage-clover=coverage.clover --verbose
+script: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover --verbose
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-A PHP Wrapper for use with the [TMDB API](http://docs.themoviedb.apiary.io/).
----------------
+# A PHP Wrapper for use with the [TMDB API](http://docs.themoviedb.apiary.io/).
+
 [![License](https://poser.pugx.org/php-tmdb/api/license.png)](https://packagist.org/packages/php-tmdb/api)
 [![Build Status](https://travis-ci.org/php-tmdb/api.svg?branch=2.0)](https://travis-ci.org/php-tmdb/api)
 [![Code Coverage](https://scrutinizer-ci.com/g/php-tmdb/api/badges/coverage.png?b=2.0)](https://scrutinizer-ci.com/g/php-tmdb/api/?branch=2.0)
 [![HHVM Status](http://hhvm.h4cc.de/badge/php-tmdb/api.svg)](http://hhvm.h4cc.de/package/php-tmdb/api)
 
-Inspired by [php-github-api](https://github.com/KnpLabs/php-github-api), [php-gitlab-api](https://github.com/m4tthumphrey/php-gitlab-api/) and the Symfony2 Community.
+Inspired by [php-github-api](https://github.com/KnpLabs/php-github-api), [php-gitlab-api](https://github.com/m4tthumphrey/php-gitlab-api/) and the Symfony Community.
 
 If you have any questions or feature requests, please visit the [google+ community](https://plus.google.com/communities/113544625011244846907).
 
-Stable
-----------------
+## Stable
 
 [![Latest Stable Version](https://poser.pugx.org/php-tmdb/api/v/stable.svg)](https://packagist.org/packages/php-tmdb/api)
 [![Latest Unstable Version](https://poser.pugx.org/php-tmdb/api/v/unstable.svg)](https://packagist.org/packages/php-tmdb/api)
@@ -22,36 +21,34 @@ Currently unit tests are run on travis, with the following versions:
 - 5.4
 - 5.5
 - 5.6
-- 7
-- nightly ( failures allowed )
-- HHVM ( failures allowed )
+- 7.0
+- 7.1
+- nightly (failures allowed)
+- HHVM (failures allowed)
 
-Features
---------
+## Features
 
-**Main features**
+### Main features
 
-- An complete integration of all the TMDB API has to offer ( accounts, movies, tv etc. _if something is missing I haven't added the updates yet!_ ).
-- Array implementation of the movie database ( RAW )
-- Model implementation of the movie database ( By making use of the repositories )
+- An complete integration of all the TMDB API has to offer (accounts, movies, tv etc. _if something is missing I haven't added the updates yet!_).
+- Array implementation of the movie database (RAW)
+- Model implementation of the movie database (By making use of the repositories)
 - An `ImageHelper` class to help build image urls or html <img> elements.
 
-**Other things worth mentioning**
+### Other things worth mentioning
 
 - Retry subscriber enabled by default to handle any rate limit errors.
 - Caching subscriber enabled by default, based on `max-age` headers returned by TMDB, requires `doctrine-cache`.
 - Logging subscriber and is optional, requires `monolog`. Could prove useful during development.
 
-Plug-ins
---------
+## Plug-ins
 
-- Symfony2
-  - [php-tmdb/symfony](https://github.com/php-tmdb/symfony), _yet to updated to 2.0_.
+- Symfony
+  - [php-tmdb/symfony](https://github.com/php-tmdb/symfony).
 - Laravel
   - [php-tmdb/laravel](https://github.com/php-tmdb/laravel).
 
-Installation
-------------
+## Installation
 
 Install Composer
 
@@ -59,11 +56,11 @@ Install Composer
 $ curl -sS https://getcomposer.org/installer | php
 $ sudo mv composer.phar /usr/local/bin/composer
 ```
-_You are not obliged to move the composer.phar file to your /usr/local/bin, it is however considered easy to have an global installation._
+_You are not obliged to move the `composer.phar` file to your `/usr/local/bin`, it is however considered easy to have an global installation._
 
-Add the following to your require block in composer.json config
+Add the following to your require block in `composer.json` config
 
-```
+```json
 "php-tmdb/api": "~2.0"
 ```
 
@@ -71,7 +68,7 @@ __If your new to composer and have no clue what I'm talking about__
 
 Just create a file named `composer.json` in your document root:
 
-```
+```json
 {
     "require": {
         "php-tmdb/api": "~2.0"
@@ -91,10 +88,9 @@ Include Composer's autoloader:
 require_once dirname(__DIR__).'/vendor/autoload.php';
 ```
 
-To use the examples provided, copy the apikey.php.dist to apikey.php and change the settings. 
+To use the examples provided, copy the `apikey.php.dist` to `apikey.php` and change the settings. 
 
-Constructing the Client
------------------------
+## Constructing the Client
 
 First we always have to construct the client:
 
@@ -103,7 +99,7 @@ $token  = new \Tmdb\ApiToken('your_tmdb_api_key_here');
 $client = new \Tmdb\Client($token);
 ```
 
-If you'd like to make unsecure requests ( by __default__ we use secure requests ).
+If you'd like to make unsecure requests (by __default__ we use secure requests).
 
 ```php
 $client = new \Tmdb\Client($token, ['secure' => false]);
@@ -111,7 +107,7 @@ $client = new \Tmdb\Client($token, ['secure' => false]);
 
 Caching is enabled by default, and uses a slow filesystem handler, which you can either:
 
-    Replace the `path` of the storage of, by supplying the option in the client:
+  - Replace the `path` of the storage of, by supplying the option in the client:
     
 ```php
 $client = new \Tmdb\Client($token, [
@@ -120,7 +116,7 @@ $client = new \Tmdb\Client($token, [
     ]
 ]);
 ```
-    Or replace the whole implementation with another CacheStorage of Doctrine:
+  - Or replace the whole implementation with another CacheStorage of Doctrine:
     
 ```php
 $client = new \Tmdb\Client($token, [
@@ -142,7 +138,7 @@ $client = new \Tmdb\Client($token, [
 ]);
 ```
 
-If you want to add some logging capabilities ( requires `monolog/monolog` ), defaulting to the filesystem;
+If you want to add some logging capabilities (requires `monolog/monolog`), defaulting to the filesystem;
 
 ```php
 $client = new \Tmdb\Client($token, [
@@ -166,8 +162,7 @@ $client = new \Tmdb\Client($token, [
 ]);
 ```
 
-General API Usage
------------------
+## General API Usage
 
 If your looking for a simple array entry point the API namespace is the place to be.
 
@@ -181,8 +176,7 @@ If you want to provide any other query arguments.
 $movie = $client->getMoviesApi()->getMovie(550, array('language' => 'en'));
 ```
 
-Model Usage
------------
+## Model Usage
 
 However the library can also be used in an object oriented manner, which I reckon is the __preferred__ way of doing things.
 
@@ -204,8 +198,7 @@ $topRated = $repository->getTopRated(array('page' => 3));
 $popular = $repository->getPopular();
 ```
 
-Some other useful hints
------------------------
+## Some other useful hints
 
 ### Event Dispatching
 
@@ -268,16 +261,15 @@ _And there are more Collections which provide filters, but you will find those o
 
 ### The `GenericCollection` and the `ResultCollection`
 
-The `GenericCollection` holds any collection of objects ( e.g. an collection of movies ).
+The `GenericCollection` holds any collection of objects (e.g. an collection of movies).
 
-The `ResultCollection` is an extension of the `GenericCollection`, and inherits the response parameters _( page, total_pages, total_results )_ from an result set,
+The `ResultCollection` is an extension of the `GenericCollection`, and inherits the response parameters _(page, total_pages, total_results)_ from an result set,
 this can be used to create paginators.
 
-Help & Donate
---------------
+## Help & Donate
 
-If you use this in a project whether personal or business, I'd like to know where it is being used, __so please drop me an e-mail :-)__!
+If you use this in a project whether personal or business, I'd like to know where it is being used, __so please drop me an e-mail!__ :-)
 
-If this project saved you a bunch of work, or you just simply appreciate my efforts, please consider donating a beer ( or two ;) )!
+If this project saved you a bunch of work, or you just simply appreciate my efforts, please consider donating a beer (or two ;))!
 
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=SMLZ362KQ8K8W"><img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"></a>

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0",
+        "phpunit/phpunit": "~4.8||~5.0",
         "monolog/monolog": ">=1.11.0"
     },
     "suggest": {


### PR DESCRIPTION
* Add symfony 3.1+ and php 7.1 to matrix
* Use phpunit installed locally by composer instead of global
* Add phpunit 4.8 to version constraint
  phpunit ^5.0 requires php 5.6+, so tests for php 5.4 and 5.5 are failing. As branch '2.0' claims to support php 5.4+ - add phpunit 4.8 to allow test running on php runtimes <5.6
* Update README
  Add php 7.1 to the list of runtimes, get rid of 'Symfony2' naming - use versionless 'Symfony' instead, formatting adjustments