### PR TITLE
Fix tagged images

### DIFF
--- a/lib/Tmdb/Factory/ImageFactory.php
+++ b/lib/Tmdb/Factory/ImageFactory.php
@@ -64,11 +64,7 @@ class ImageFactory extends AbstractFactory
      */
     public function createMediaImage(array $data = [])
     {
-        if (!array_key_exists('image_type', $data)) {
-            throw new \RuntimeException('Unable to detect the image type.');
-        }
-
-        $type  = $this->resolveImageType($data['image_type']);
+        $type  = $this->resolveImageType(array_key_exists('image_type', $data) ? $data['image_type'] : null);
         $image = $this->hydrate($type, $data);
 
         if (array_key_exists('media', $data) && array_key_exists('media_type', $data)) {

--- a/lib/Tmdb/Factory/ImageFactory.php
+++ b/lib/Tmdb/Factory/ImageFactory.php
@@ -109,7 +109,7 @@ class ImageFactory extends AbstractFactory
             $image->setMedia($media);
         }
 
-        return $this->hydrate($type, $data);
+        return $image;
     }
 
     /**

--- a/test/Tmdb/Tests/Factory/ImageFactoryTest.php
+++ b/test/Tmdb/Tests/Factory/ImageFactoryTest.php
@@ -186,6 +186,16 @@ class ImageFactoryTest extends TestCase
         }
     }
 
+    /**
+     * @test
+     */
+    public function shouldSetMedia()
+    {
+        $image = $this->getFactory()->createMediaImage($this->loadByFile('images/tagged_image.json'));
+
+        $this->assertInstanceOf('Tmdb\Model\Movie', $image->getMedia());
+    }
+
     protected function getFactoryClass()
     {
         return 'Tmdb\Factory\ImageFactory';

--- a/test/Tmdb/Tests/Resources/images/tagged_image.json
+++ b/test/Tmdb/Tests/Resources/images/tagged_image.json
@@ -1,0 +1,29 @@
+{
+    "iso_639_1": null,
+    "vote_count": 72,
+    "media_type": "movie",
+    "file_path": "/lIv1QinFqz4dlp5U4lQ6HaiskOZ.jpg",
+    "aspect_ratio": 0.66666666666667,
+    "media": {
+        "release_date": "2014-10-10",
+        "vote_count": 3749,
+        "video": false,
+        "adult": false,
+        "vote_average": 8.3,
+        "title": "Whiplash",
+        "genre_ids": [
+            18,
+            10402
+        ],
+        "original_language": "en",
+        "original_title": "Whiplash",
+        "popularity": 11.036484,
+        "id": 244786,
+        "backdrop_path": "/6bbZ6XyvgfjhQwbplnUh1LSj1ky.jpg",
+        "overview": "A talented young drummer begins to pursue perfection.",
+        "poster_path": "/lIv1QinFqz4dlp5U4lQ6HaiskOZ.jpg"
+    },
+    "height": 2100,
+    "vote_average": 6.424,
+    "width": 1400
+}


### PR DESCRIPTION
This patch fixes the issue described in #146. Now `createMediaImage()` just creates a generic image when no type is set explicitly. In addition, the hydration was done twice before (which might lead to overwritten data) and is now fixed as well.