### PR TITLE
Pass relative path to HTTP adapters

### DIFF
--- a/lib/Tmdb/Client.php
+++ b/lib/Tmdb/Client.php
@@ -169,7 +169,7 @@ class Client
     /**
      * Construct the http client
      *
-     * In case you are implementing your own adapter, the base url will be passed on through the $parameters array
+     * In case you are implementing your own adapter, the base url will be passed on through the options bag
      * at every call in the respective get / post methods etc. of the adapter.
      *
      * @return void
@@ -334,7 +334,7 @@ class Client
 
         if (!$this->options['adapter']) {
             $this->options['adapter'] = new GuzzleAdapter(
-                new \GuzzleHttp\Client(['base_url' => $this->options['base_url']])
+                new \GuzzleHttp\Client()
             );
         }
 

--- a/lib/Tmdb/HttpClient/Adapter/GuzzleAdapter.php
+++ b/lib/Tmdb/HttpClient/Adapter/GuzzleAdapter.php
@@ -104,6 +104,7 @@ class GuzzleAdapter extends AbstractAdapter
         $this->request = $request;
 
         return [
+            'base_uri' => $request->getOptions()->get('base_url'),
             'headers'  => $request->getHeaders()->all(),
             'query'    => $request->getParameters()->all()
         ];

--- a/lib/Tmdb/HttpClient/HttpClient.php
+++ b/lib/Tmdb/HttpClient/HttpClient.php
@@ -62,6 +62,8 @@ class HttpClient
      * The base url to built requests on top of
      *
      * @var null
+     *
+     * @deprecated since 2.1.10, to be removed in 3.0. Use `base_url` of the request options instead.
      */
     protected $base_url = null;
 
@@ -95,11 +97,6 @@ class HttpClient
 
         $this->setAdapter($this->options['adapter']);
         $this->processOptions();
-    }
-
-    private function constructSecureUrl($path)
-    {
-        return 'https://' . $this->base_url . $path;
     }
 
     /**
@@ -229,7 +226,7 @@ class HttpClient
     private function send($path, $method, array $parameters = [], array $headers = [], $body = null)
     {
         $request = $this->createRequest(
-            $this->constructSecureUrl($path),
+            $path,
             $method,
             $parameters,
             $headers,

--- a/test/Tmdb/Tests/ClientTest.php
+++ b/test/Tmdb/Tests/ClientTest.php
@@ -89,6 +89,29 @@ class ClientTest extends \Tmdb\Tests\TestCase
         );
     }
 
+    /**
+     * @test
+     */
+    public function shouldRespectSecureClientOption()
+    {
+        $token  = new ApiToken(self::API_TOKEN);
+
+        $client = new \Tmdb\Client($token);
+        $options = $client->getOptions();
+        $this->assertTrue(true === $options['secure']);
+        $this->assertTrue(false !== strpos($options['base_url'], 'https://'));
+
+        $client = new \Tmdb\Client($token, ['secure' => true]);
+        $options = $client->getOptions();
+        $this->assertTrue(true === $options['secure']);
+        $this->assertTrue(false !== strpos($options['base_url'], 'https://'));
+
+        $client = new \Tmdb\Client($token, ['secure' => false]);
+        $options = $client->getOptions();
+        $this->assertTrue(false === $options['secure']);
+        $this->assertTrue(false !== strpos($options['base_url'], 'http://'));
+    }
+
     public function testShouldSwitchHttpScheme()
     {
         $token  = new ApiToken(self::API_TOKEN);

--- a/test/Tmdb/Tests/TestCase.php
+++ b/test/Tmdb/Tests/TestCase.php
@@ -138,14 +138,14 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     /**
      * Get the expected request that will deliver a response
      *
-     * @param $path
+     * @param  string  $url
      * @param  array   $parameters
      * @param  string  $method
      * @param  array   $headers
      * @param  null    $body
      * @return Request
      */
-    protected function getRequest($path, $parameters = [], $method = 'GET', $headers = [], $body = null)
+    protected function getRequest($url, $parameters = [], $method = 'GET', $headers = [], $body = null)
     {
         if (
             $method == 'POST'  ||
@@ -160,6 +160,13 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
         $headers['Accept']     = 'application/json';
         $headers['User-Agent'] = sprintf('wtfzdotnet/php-tmdb-api (v%s)', Client::VERSION);
+
+        $baseUrl = 'https://api.themoviedb.org/3/';
+        if (strpos($url, $baseUrl) === 0) {
+            $path = substr($url, strlen($baseUrl));
+        } else {
+            $path = $url;
+        }
 
         $request = new Request(
             $path,
@@ -186,7 +193,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
             ],
             'adapter' => $this->createMock('Tmdb\HttpClient\Adapter\AdapterInterface'),
             'host'    => 'api.themoviedb.org/3/',
-            'base_url' => 'https://api.themoviedb.org/3/',
+            'base_url' => $baseUrl,
             'session_token' => null,
             'event_dispatcher' => $this->eventDispatcher
         ]));


### PR DESCRIPTION
This patch restores the way paths are stored in `Tmdb\HttpClient\Request`. The base URL is no longer part of the path and is passed to the HTTP adapter as part of the options bag (fixes #145).

Note: Custom HTTP adapters which do not follow the [documented](https://github.com/php-tmdb/api/blob/49896c9dfac88f859faedd7d1601a6d68e5d28cb/lib/Tmdb/Client.php#L172-L173) practice will probably break after applying this change.