### PR TITLE
Pass relative path to HTTP adapters, 2.0 branch

### DIFF
--- a/lib/Tmdb/Client.php
+++ b/lib/Tmdb/Client.php
@@ -169,7 +169,7 @@ class Client
     /**
      * Construct the http client
      *
-     * In case you are implementing your own adapter, the base url will be passed on through the $parameters array
+     * In case you are implementing your own adapter, the base url will be passed on through the options bag
      * at every call in the respective get / post methods etc. of the adapter.
      *
      * @return void
@@ -334,7 +334,7 @@ class Client
 
         if (!$this->options['adapter']) {
             $this->options['adapter'] = new GuzzleAdapter(
-                new \GuzzleHttp\Client(['base_url' => $this->options['base_url']])
+                new \GuzzleHttp\Client()
             );
         }
 

--- a/lib/Tmdb/HttpClient/Adapter/GuzzleAdapter.php
+++ b/lib/Tmdb/HttpClient/Adapter/GuzzleAdapter.php
@@ -86,6 +86,7 @@ class GuzzleAdapter extends AbstractAdapter
         $this->request = $request;
 
         return [
+            'base_uri' => $request->getOptions()->get('base_url'),
             'headers'  => $request->getHeaders()->all(),
             'query'    => $request->getParameters()->all()
         ];

--- a/lib/Tmdb/HttpClient/HttpClient.php
+++ b/lib/Tmdb/HttpClient/HttpClient.php
@@ -64,6 +64,8 @@ class HttpClient
      * The base url to built requests on top of
      *
      * @var null
+     *
+     * @deprecated since 2.0.19, to be removed in 3.0. Use `base_url` of the request options instead.
      */
     protected $base_url = null;
 

--- a/test/Tmdb/Tests/ClientTest.php
+++ b/test/Tmdb/Tests/ClientTest.php
@@ -89,6 +89,29 @@ class ClientTest extends \Tmdb\Tests\TestCase
         );
     }
 
+    /**
+     * @test
+     */
+    public function shouldRespectSecureClientOption()
+    {
+        $token  = new ApiToken(self::API_TOKEN);
+
+        $client = new \Tmdb\Client($token);
+        $options = $client->getOptions();
+        $this->assertTrue(true === $options['secure']);
+        $this->assertTrue(false !== strpos($options['base_url'], 'https://'));
+
+        $client = new \Tmdb\Client($token, ['secure' => true]);
+        $options = $client->getOptions();
+        $this->assertTrue(true === $options['secure']);
+        $this->assertTrue(false !== strpos($options['base_url'], 'https://'));
+
+        $client = new \Tmdb\Client($token, ['secure' => false]);
+        $options = $client->getOptions();
+        $this->assertTrue(false === $options['secure']);
+        $this->assertTrue(false !== strpos($options['base_url'], 'http://'));
+    }
+
     public function testShouldSwitchHttpScheme()
     {
         $token  = new ApiToken(self::API_TOKEN);

--- a/test/Tmdb/Tests/TestCase.php
+++ b/test/Tmdb/Tests/TestCase.php
@@ -142,14 +142,14 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     /**
      * Get the expected request that will deliver a response
      *
-     * @param $path
+     * @param  string  $url
      * @param  array   $parameters
      * @param  string  $method
      * @param  array   $headers
      * @param  null    $body
      * @return Request
      */
-    protected function getRequest($path, $parameters = [], $method = 'GET', $headers = [], $body = null)
+    protected function getRequest($url, $parameters = [], $method = 'GET', $headers = [], $body = null)
     {
         if (
             $method == 'POST'  ||
@@ -164,6 +164,13 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
         $headers['Accept']     = 'application/json';
         $headers['User-Agent'] = sprintf('wtfzdotnet/php-tmdb-api (v%s)', Client::VERSION);
+
+        $baseUrl = 'https://api.themoviedb.org/3/';
+        if (strpos($url, $baseUrl) === 0) {
+            $path = substr($url, strlen($baseUrl));
+        } else {
+            $path = $url;
+        }
 
         $request = new Request(
             $path,
@@ -190,7 +197,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
             ],
             'adapter' => $this->getMock('Tmdb\HttpClient\Adapter\AdapterInterface'),
             'host'    => 'api.themoviedb.org/3/',
-            'base_url' => 'https://api.themoviedb.org/3/',
+            'base_url' => $baseUrl,
             'session_token' => null,
             'event_dispatcher' => $this->eventDispatcher
         ]));


### PR DESCRIPTION
This is a follow-up #149 for `2.0` branch, quote from the initial PR:

> This patch restores the way paths are stored in `Tmdb\HttpClient\Request`. The base URL is no longer part of the path and is passed to the HTTP adapter as part of the options bag (fixes #145).
> 
> Note: Custom HTTP adapters which do not follow the [documented](https://github.com/php-tmdb/api/blob/2.0/lib/Tmdb/Client.php#L172-L173) practice will probably break after applying this change.