### PR TITLE
Fix fatal error on php-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: false
 language: php
 
+php:
+  - 5.6
+  - nightly
+  - hhvm
+
 before_script:
   - composer self-update
   - if [ "$SF_EVT_DISPATCHER_VERSION" != "" ]; then composer require --no-update symfony/event-dispatcher:${SF_EVT_DISPATCHER_VERSION}; fi;

--- a/lib/Tmdb/Factory/People/CastFactory.php
+++ b/lib/Tmdb/Factory/People/CastFactory.php
@@ -23,9 +23,9 @@ class CastFactory extends PeopleFactory
 {
     /**
      * {@inheritdoc}
-     * @param \Tmdb\Model\Person\CastMember $person
+     * @param \Tmdb\Model\Person\CastMember|null $person
      */
-    public function createCollection(array $data = [], $person = null)
+    public function createCollection(array $data = [], $person = null, $collection = null)
     {
         $collection = new Cast();
 

--- a/lib/Tmdb/Factory/People/CrewFactory.php
+++ b/lib/Tmdb/Factory/People/CrewFactory.php
@@ -23,9 +23,9 @@ class CrewFactory extends PeopleFactory
 {
     /**
      * {@inheritdoc}
-     * @param \Tmdb\Model\Person\CrewMember $person
+     * @param \Tmdb\Model\Person\CrewMember|null $person
      */
-    public function createCollection(array $data = [], $person = null)
+    public function createCollection(array $data = [], $person = null, $collection = null)
     {
         $collection = new Crew();
 

--- a/lib/Tmdb/Factory/People/GuestStarFactory.php
+++ b/lib/Tmdb/Factory/People/GuestStarFactory.php
@@ -23,9 +23,9 @@ class GuestStarFactory extends PeopleFactory
 {
     /**
      * {@inheritdoc}
-     * @param \Tmdb\Model\Person\CastMember $person
+     * @param \Tmdb\Model\Person\CastMember|null $person
      */
-    public function createCollection(array $data = [], $person = null)
+    public function createCollection(array $data = [], $person = null, $collection = null)
     {
         $collection = new GuestStars();
 

--- a/lib/Tmdb/Factory/PeopleFactory.php
+++ b/lib/Tmdb/Factory/PeopleFactory.php
@@ -17,6 +17,7 @@ use Tmdb\Factory\Common\ChangeFactory;
 use Tmdb\HttpClient\HttpClient;
 use Tmdb\Model\Collection\People;
 use Tmdb\Model\Common\ExternalIds;
+use Tmdb\Model\Common\GenericCollection;
 use Tmdb\Model\Person\CastMember;
 use Tmdb\Model\Person\CrewMember;
 use Tmdb\Model\Person;
@@ -165,6 +166,8 @@ class PeopleFactory extends AbstractFactory
 
     /**
      * {@inheritdoc}
+     * @param Person\AbstractMember|null $person
+     * @param GenericCollection|null $collection
      */
     public function createCollection(array $data = [], $person = null, $collection = null)
     {


### PR DESCRIPTION
Make declaration of overloaded createCollection() compatible between parent and child classes.

Also provide min/max/hhvm runtimes for travis.

Fixes php-tmdb/symfony#23