### PR TITLE
Allow kevinrob/guzzle-cache-middleware 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "guzzlehttp/guzzle": "~6.0",
         "psr/log": "~1.0",
         "doctrine/cache": "^1.6",
-        "kevinrob/guzzle-cache-middleware": "^1.2",
+        "kevinrob/guzzle-cache-middleware": "^1.2 || ^2.0",
         "rtheunissen/guzzle-log-middleware": "^0.4.0"
     },
     "require-dev": {


### PR DESCRIPTION
There does not seem to be any BC break that affects php-tmdb. The only
documented BC break is here:
https://github.com/Kevinrob/guzzle-cache-middleware/pull/75