### PR TITLE
Fix hydration of nested episode credits

### DIFF
--- a/lib/Tmdb/Factory/TvEpisodeFactory.php
+++ b/lib/Tmdb/Factory/TvEpisodeFactory.php
@@ -90,38 +90,42 @@ class TvEpisodeFactory extends AbstractFactory
         $tvEpisode = new Episode();
 
         if (array_key_exists('credits', $data)) {
-            if (array_key_exists('cast', $data['credits'])) {
-                $tvEpisode
-                    ->getCredits()
-                    ->setCast(
-                        $this->getCastFactory()
-                            ->createCollection(
-                                $data['credits']['cast'],
-                                new CastMember()
-                            )
-                    );
-            }
+            $credits = $data['credits'];
+        } else {
+            $credits = $data;
+        }
 
-            if (array_key_exists('crew', $data['credits'])) {
-                $tvEpisode->getCredits()->setCrew(
-                    $this->getCrewFactory()->createCollection(
-                        $data['credits']['crew'],
-                        new CrewMember()
-                    )
+        if (array_key_exists('cast', $credits)) {
+            $tvEpisode
+                ->getCredits()
+                ->setCast(
+                    $this->getCastFactory()
+                        ->createCollection(
+                            $credits['cast'],
+                            new CastMember()
+                        )
                 );
-            }
+        }
 
-            if (array_key_exists('guest_stars', $data['credits'])) {
-                $tvEpisode
-                    ->getCredits()
-                    ->setGuestStars(
-                        $this->getGuestStarFactory()
-                            ->createCollection(
-                                $data['credits']['guest_stars'],
-                                new GuestStar()
-                            )
-                    );
-            }
+        if (array_key_exists('crew', $credits)) {
+            $tvEpisode->getCredits()->setCrew(
+                $this->getCrewFactory()->createCollection(
+                    $credits['crew'],
+                    new CrewMember()
+                )
+            );
+        }
+
+        if (array_key_exists('guest_stars', $credits)) {
+            $tvEpisode
+                ->getCredits()
+                ->setGuestStars(
+                    $this->getGuestStarFactory()
+                        ->createCollection(
+                            $credits['guest_stars'],
+                            new GuestStar()
+                        )
+                );
         }
 
         /** External ids */

--- a/test/Tmdb/Tests/Factory/TvSeasonFactoryTest.php
+++ b/test/Tmdb/Tests/Factory/TvSeasonFactoryTest.php
@@ -86,6 +86,7 @@ class TvSeasonFactoryTest extends TestCase
         $this->assertEquals(3573, $this->season->getId());
         $this->assertEquals('/rCdISteF1GPvPsy0a5L0LDffjtP.jpg', $this->season->getPosterPath());
         $this->assertEquals(2, $this->season->getSeasonNumber());
+        $this->assertCount(2, $this->season->getEpisodes()->filterId(972873)->getCredits()->getCrew());
     }
 
     protected function getFactoryClass()

--- a/test/Tmdb/Tests/Resources/tv/season/all.json
+++ b/test/Tmdb/Tests/Resources/tv/season/all.json
@@ -3,7 +3,28 @@
     "episodes":[
         {
             "air_date":"2009-03-08",
+            "crew": [
+                {
+                    "credit_id": "5254227b760ee31328000d85",
+                    "department": "Directing",
+                    "gender": null,
+                    "id": 17419,
+                    "job": "Director",
+                    "name": "Bryan Cranston",
+                    "profile_path": "/fnglrIFnI5cK4OAh66AZN86mkFq.jpg"
+                },
+                {
+                    "credit_id": "52750452760ee345a913253e",
+                    "department": "Writing",
+                    "gender": null,
+                    "id": 212407,
+                    "job": "Writer",
+                    "name": "J. Roberts",
+                    "profile_path": null
+                }
+            ],
             "episode_number":1,
+            "id": 972873,
             "name":"Seven Thirty-Seven",
             "overview":"Walt and Jesse try to figure a way out of their partnership with Tuco. Hank tries to mend the fences between Marie and Skyler.",
             "still_path":"\/bwgioLAgihPCUK21rLWocDaDM3g.jpg",


### PR DESCRIPTION
When fetching a season from the API, the credits of its episodes are not nested under `credits`. Instead, they are directly embedded in the episode root object.

Fixes: #171 