### PR TITLE
Fixes Y-d-m format

### DIFF
--- a/lib/Tmdb/Model/Person.php
+++ b/lib/Tmdb/Model/Person.php
@@ -265,7 +265,12 @@ class Person extends AbstractModel implements PersonInterface
     public function setDeathday($deathday)
     {
         if (!$deathday instanceof \DateTime && !empty($deathday)) {
-            $deathday = new \DateTime($deathday);
+        	// Is the format Y-m-d ?
+        	if(strtotime($deathday) === false) {
+        		$deathday = \DateTime::createFromFormat('Y-d-m', $deathday);
+        	} else {
+        		$deathday = new \DateTime($deathday);
+        	}
         }
 
         if (empty($deathday)) {


### PR DESCRIPTION
In some cases, Y-d-m is returned for setDeathday (ex. person Tmdb ID 1081524).

```DateTime::__construct(): Failed to parse time string (1-16-2016) at position 0 (1): Unexpected character```