### PR TITLE
Fix property name of job list

### DIFF
--- a/lib/Tmdb/Model/Job.php
+++ b/lib/Tmdb/Model/Job.php
@@ -20,7 +20,7 @@ class Job extends AbstractModel
 {
     public static $properties = [
         'department',
-        'job_list'
+        'jobs'
     ];
 
     /**
@@ -31,7 +31,7 @@ class Job extends AbstractModel
     /**
      * @var array
      */
-    private $jobList;
+    private $jobs;
 
     /**
      * @param  string $department
@@ -54,16 +54,16 @@ class Job extends AbstractModel
      * @param  array $jobList
      * @return $this
      */
-    public function setJobList(array $jobList)
+    public function setJobs(array $jobs)
     {
-        $this->jobList = $jobList;
+        $this->jobs = $jobs;
     }
 
     /**
      * @return array
      */
-    public function getJobList()
+    public function getJobs()
     {
-        return $this->jobList;
+        return $this->jobs;
     }
 }


### PR DESCRIPTION
Hello,
I've got an issue with list of jobs. I submit this modification in order to fix this issue. Otherwise the endpoint to get job list is not the same in TMDB API documentation https://developers.themoviedb.org/3/configuration/get-jobs : `/configuration/jobs` but the endpoint in the library `job/list` seems to be ok.
Regards,
Joël