### PR TITLE
Use correct factory for TV episodes

### DIFF
--- a/lib/Tmdb/Factory/FindFactory.php
+++ b/lib/Tmdb/Factory/FindFactory.php
@@ -86,7 +86,7 @@ class FindFactory extends AbstractFactory
         }
 
         if (array_key_exists('tv_episode_results', $data)) {
-            $find->setTvEpisodeResults($this->getTvSeasonFactory()->createCollection($data['tv_episode_results']));
+            $find->setTvEpisodeResults($this->getTvEpisodeFactory()->createCollection($data['tv_episode_results']));
         }
 
         return $find;


### PR DESCRIPTION
Diff should be self-explanatory, but currently `getTvEpisodeResults()` after using `FindRepository` returns a collection of seasons instead of episodes :)