### PR TITLE
Fix phpdoc return for searchCollection method

### DIFF
--- a/lib/Tmdb/Repository/SearchRepository.php
+++ b/lib/Tmdb/Repository/SearchRepository.php
@@ -110,7 +110,7 @@ class SearchRepository extends AbstractRepository
      * @param CollectionSearchQuery $parameters
      * @param array                 $headers
      *
-     * @return ResultCollection[]
+     * @return ResultCollection
      */
     public function searchCollection($query, CollectionSearchQuery $parameters, array $headers = [])
     {


### PR DESCRIPTION
Hi, 

The phpdoc for the `SearchRepository::searchCollection` method simply returns a ResultCollection and not ResultCollection array ;)