### PR TITLE
Add "known_for_department" field to the Person Model

### DIFF
--- a/lib/Tmdb/Model/Person.php
+++ b/lib/Tmdb/Model/Person.php
@@ -62,6 +62,11 @@ class Person extends AbstractModel implements PersonInterface
     /**
      * @var string
      */
+    private $knownForDepartment;
+
+    /**
+     * @var string
+     */
     private $name;
 
     /**
@@ -136,6 +141,7 @@ class Person extends AbstractModel implements PersonInterface
         'deathday',
         'homepage',
         'id',
+        'known_for_department',
         'name',
         'place_of_birth',
         'profile_path',
@@ -345,6 +351,25 @@ class Person extends AbstractModel implements PersonInterface
     public function getImages()
     {
         return $this->images;
+    }
+
+    /**
+     * @param  string $knownForDepartment
+     * @return $this
+     */
+    public function setKnownForDepartment($knownForDepartment)
+    {
+        $this->knownForDepartment = $knownForDepartment;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKnownForDepartment()
+    {
+        return $this->knownForDepartment;
     }
 
     /**


### PR DESCRIPTION
This PR adds the "known_for_department" field, which was introduced July 17, 2018 as the TMDB API Documentation states, to the Person Model.
This field basically shows for what department a person is mostly know for.
So, for example, it would be "Acting" for Brad Pitt, "Directing" for Quentin Tarantino and "Production" for Kevin Feige.

https://developers.themoviedb.org/3/people/get-person-details