### PR TITLE
PHP 8 Fixes

### DIFF
--- a/lib/Tmdb/Factory/AbstractFactory.php
+++ b/lib/Tmdb/Factory/AbstractFactory.php
@@ -237,8 +237,8 @@ abstract class AbstractFactory
      * @return GenericCollection
      */
     protected function createCustomCollection(
-        array $data = [],
-        AbstractModel $class = null,
+        array $data,
+        AbstractModel $class,
         GenericCollection $collection
     ) {
         if (!$class || !$collection) {


### PR DESCRIPTION
PHP 8 has deprecated required parameters following optional parameters.