### PR TITLE
Preserve dots in parameters in RequestQueryHelper. Fixes #236

### DIFF
--- a/lib/Tmdb/Helper/RequestQueryHelper.php
+++ b/lib/Tmdb/Helper/RequestQueryHelper.php
@@ -41,7 +41,11 @@ class RequestQueryHelper
     private function addQueryToUri(UriInterface $uri, $key, $value): UriInterface
     {
         $parameters = [];
-        parse_str($uri->getQuery(), $parameters);
+        foreach (explode('&', $uri->getQuery()) as $curParam) {
+            if ($curParam && ($curParamParts = explode('=', $curParam))) {
+                $parameters[urldecode($curParamParts[0])] = urldecode($curParamParts[1] ?? null);
+            }
+        }
         $parameters[$key] = $value;
 
         ksort($parameters);


### PR DESCRIPTION
- Fixes #236 

`parse_str` converts periods/dots in parameters to underscores, which ruins TMDb keys such as `air_date_gte`

This is a naive implementation of query string parsing, but hopefully is adequate in this context.