### PR TITLE
Add 'alt' param to getHtml function

### DIFF
--- a/lib/Tmdb/Helper/ImageHelper.php
+++ b/lib/Tmdb/Helper/ImageHelper.php
@@ -57,9 +57,10 @@ class ImageHelper
      * @param string $size
      * @param int|null $width
      * @param int|null $height
+     * @param string $alt
      * @return string
      */
-    public function getHtml($image, $size = 'original', $width = null, $height = null)
+    public function getHtml($image, $size = 'original', $width = null, $height = null, $alt = '')
     {
         if ($image instanceof Image) {
             if (null == $image->getFilePath()) {
@@ -86,10 +87,11 @@ class ImageHelper
         }
 
         return sprintf(
-            '<img src="%s" width="%s" height="%s" />',
+            '<img src="%s" width="%s" height="%s" alt="%s"/>',
             $this->getUrl($image, $size),
             $width,
-            $height
+            $height,
+            $alt
         );
     }
 

--- a/lib/Tmdb/Helper/ImageHelper.php
+++ b/lib/Tmdb/Helper/ImageHelper.php
@@ -57,10 +57,10 @@ class ImageHelper
      * @param string $size
      * @param int|null $width
      * @param int|null $height
-     * @param string $alt
+     * @param string $title
      * @return string
      */
-    public function getHtml($image, $size = 'original', $width = null, $height = null, $alt = '')
+    public function getHtml($image, $size = 'original', $width = null, $height = null, $title = '')
     {
         if ($image instanceof Image) {
             if (null == $image->getFilePath()) {
@@ -87,11 +87,12 @@ class ImageHelper
         }
 
         return sprintf(
-            '<img src="%s" width="%s" height="%s" alt="%s"/>',
+            '<img src="%s" width="%s" height="%s" title="%s" alt="%s"/>',
             $this->getUrl($image, $size),
             $width,
             $height,
-            $alt
+            $title,
+            $title
         );
     }
 

--- a/lib/Tmdb/Helper/ImageHelper.php
+++ b/lib/Tmdb/Helper/ImageHelper.php
@@ -57,10 +57,11 @@ class ImageHelper
      * @param string $size
      * @param int|null $width
      * @param int|null $height
+     * @param string $alt
      * @param string $title
      * @return string
      */
-    public function getHtml($image, $size = 'original', $width = null, $height = null, $title = '')
+    public function getHtml($image, $size = 'original', $width = null, $height = null, $alt = '', $title = '')
     {
         if ($image instanceof Image) {
             if (null == $image->getFilePath()) {
@@ -92,7 +93,7 @@ class ImageHelper
             $width,
             $height,
             $title,
-            $title
+            $alt
         );
     }
 


### PR DESCRIPTION
Currently the image object created by 'getHtml' function has no option to specify an alternative text (if the image is not available), not to add an title for mouse over display. This addition adds the option to specify a string to use for both.