### PR TITLE
Add PHP 8.1 type hints for ArrayAccess, IteratorAggregate, and Countable

### DIFF
--- a/lib/Tmdb/Model/Common/GenericCollection.php
+++ b/lib/Tmdb/Model/Common/GenericCollection.php
@@ -48,7 +48,7 @@ class GenericCollection implements ArrayAccess, IteratorAggregate, Countable
     /**
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->data);
     }

--- a/lib/Tmdb/Model/Common/GenericCollection.php
+++ b/lib/Tmdb/Model/Common/GenericCollection.php
@@ -56,7 +56,7 @@ class GenericCollection implements ArrayAccess, IteratorAggregate, Countable
     /**
      * @return ArrayIterator|Traversable
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->data);
     }

--- a/lib/Tmdb/Model/Common/GenericCollection.php
+++ b/lib/Tmdb/Model/Common/GenericCollection.php
@@ -288,22 +288,23 @@ class GenericCollection implements ArrayAccess, IteratorAggregate, Countable
         return $this;
     }
 
-    public function offsetExists(mixed $offset): bool
+    public function offsetExists($offset): bool
     {
         return isset($this->data[$offset]);
     }
 
-    public function offsetGet(mixed $offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
     {
         return isset($this->data[$offset]) ? $this->data[$offset] : null;
     }
 
-    public function offsetSet(mixed $offset, mixed $value): void
+    public function offsetSet($offset, $value): void
     {
         $this->data[$offset] = $value;
     }
 
-    public function offsetUnset(mixed $offset): void
+    public function offsetUnset($offset): void
     {
         unset($this->data[$offset]);
     }

--- a/lib/Tmdb/Model/Common/GenericCollection.php
+++ b/lib/Tmdb/Model/Common/GenericCollection.php
@@ -288,22 +288,22 @@ class GenericCollection implements ArrayAccess, IteratorAggregate, Countable
         return $this;
     }
 
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->data[$offset]);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return isset($this->data[$offset]) ? $this->data[$offset] : null;
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->data[$offset] = $value;
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->data[$offset]);
     }


### PR DESCRIPTION
PHP 8.1 added type hints to the `ArrayAccess`, `IteratorAggregate`, and `Countable` interfaces. This PR matches to type hints to avoid signature mismatch errors.