### PR TITLE
Use latest version of PsrLogTestDoubles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "monolog/monolog": ">=1.11.0",
         "vimeo/psalm": "^4",
         "php-http/cache-plugin": "^1.7",
-        "wmde/psr-log-test-doubles": "^2"
+        "jeroen/psr-log-test-doubles": "^3.2"
     },
     "scripts": {
         "test": "vendor/bin/phpunit",

--- a/test/Tmdb/Tests/Event/Listener/Logger/LogApiErrorListenerTest.php
+++ b/test/Tmdb/Tests/Event/Listener/Logger/LogApiErrorListenerTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Tmdb\Event\Listener\Logger\LogApiErrorListener;
 use Tmdb\Event\TmdbExceptionEvent;
 use Tmdb\Exception\TmdbApiException;
-use WMDE\PsrLogTestDoubles\LoggerSpy;
+use WMDE\PsrLogTestDoubles\LegacyLoggerSpy;
 
 class LogApiErrorListenerTest extends LoggerListenerTestCase
 {
@@ -27,7 +27,7 @@ class LogApiErrorListenerTest extends LoggerListenerTestCase
      */
     public function shouldLogApiError()
     {
-        $logger = new LoggerSpy();
+        $logger = new LegacyLoggerSpy();
         $event = new TmdbExceptionEvent(new TmdbApiException(7, 'invalid api key'));
 
         $eventDispatcher = new EventDispatcher();

--- a/test/Tmdb/Tests/Event/Listener/Logger/LogHttpMessageListenerTest.php
+++ b/test/Tmdb/Tests/Event/Listener/Logger/LogHttpMessageListenerTest.php
@@ -26,7 +26,7 @@ use Tmdb\Event\Listener\RequestListener;
 use Tmdb\Event\RequestEvent;
 use Tmdb\Event\ResponseEvent;
 use Tmdb\HttpClient\HttpClient;
-use WMDE\PsrLogTestDoubles\LoggerSpy;
+use WMDE\PsrLogTestDoubles\LegacyLoggerSpy;
 
 class LogHttpMessageListenerTest extends LoggerListenerTestCase
 {
@@ -35,7 +35,7 @@ class LogHttpMessageListenerTest extends LoggerListenerTestCase
      */
     public function shouldLogRequest()
     {
-        $logger = new LoggerSpy();
+        $logger = new LegacyLoggerSpy();
 
         $factory = new Psr17Factory();
         $request = $factory->createRequest('GET', 'http://www.test.com/foo/bar');
@@ -66,7 +66,7 @@ HEADER;
      */
     public function shouldLogResponse()
     {
-        $logger = new LoggerSpy();
+        $logger = new LegacyLoggerSpy();
 
         $factory = new Psr17Factory();
         $request = $factory->createRequest('GET', 'http://www.test.com/foo/bar');
@@ -98,7 +98,7 @@ HEADER;
      */
     public function shouldLogClientException()
     {
-        $logger = new LoggerSpy();
+        $logger = new LegacyLoggerSpy();
 
         $factory = new Psr17Factory();
         $request = $factory->createRequest('GET', 'http://www.test.com/foo/bar');

--- a/test/Tmdb/Tests/Event/Listener/Logger/LogHydrationListenerTest.php
+++ b/test/Tmdb/Tests/Event/Listener/Logger/LogHydrationListenerTest.php
@@ -19,7 +19,7 @@ use Tmdb\Event\BeforeHydrationEvent;
 use Tmdb\Event\Listener\Logger\LogHydrationListener;
 use Tmdb\Formatter\Hydration\SimpleHydrationFormatter;
 use Tmdb\Model\Movie;
-use WMDE\PsrLogTestDoubles\LoggerSpy;
+use WMDE\PsrLogTestDoubles\LegacyLoggerSpy;
 
 class LogHydrationListenerTest extends LoggerListenerTestCase
 {
@@ -28,7 +28,7 @@ class LogHydrationListenerTest extends LoggerListenerTestCase
      */
     public function shouldLogHydrationWithoutData()
     {
-        $logger = new LoggerSpy();
+        $logger = new LegacyLoggerSpy();
         $event = new BeforeHydrationEvent(new Movie(), ['id' => 123]);
 
         $eventDispatcher = new EventDispatcher();
@@ -44,7 +44,7 @@ class LogHydrationListenerTest extends LoggerListenerTestCase
      */
     public function shouldLogHydrationWithData()
     {
-        $logger = new LoggerSpy();
+        $logger = new LegacyLoggerSpy();
         $event = new BeforeHydrationEvent(new Movie(), ['id' => 123]);
 
         $eventDispatcher = new EventDispatcher();


### PR DESCRIPTION
This sets you up for PHP 8.1 and migration to `psr/log` 3.x.

Full list of changes is at https://github.com/JeroenDeDauw/PsrLogTestDoubles#release-notes