### PR TITLE
Use latest psr-log-test-doubles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "monolog/monolog": ">=1.11.0",
         "vimeo/psalm": "^4",
         "php-http/cache-plugin": "^1.7",
-        "wmde/psr-log-test-doubles": "^2"
+        "jeroen/psr-log-test-doubles": "^2.1 || ^3"
     },
     "scripts": {
         "test": "vendor/bin/phpunit",


### PR DESCRIPTION
This sets you up for PHP 8.1 and migration to psr/log 3.x. Neither of those are supported in `^2.0`.