### PR TITLE
Fix implicitly marking parameter as nullable deprecation for PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "license": "MIT",
     "name": "php-tmdb/api",
     "require": {
-        "php": "^7.3 || ^7.4 || ^8.0 || ^8.1",
+        "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "symfony/options-resolver": "^4.4 || ^5 || ^6",
         "psr/cache": "^1 || ^2 || ^3",

--- a/lib/Tmdb/Event/HydrationEvent.php
+++ b/lib/Tmdb/Event/HydrationEvent.php
@@ -111,7 +111,7 @@ class HydrationEvent extends Event
      * @param RequestInterface|null $lastRequest
      * @return self
      */
-    public function setLastRequest(RequestInterface $lastRequest = null): HydrationEvent
+    public function setLastRequest(?RequestInterface $lastRequest = null): HydrationEvent
     {
         $this->lastRequest = $lastRequest;
 
@@ -130,7 +130,7 @@ class HydrationEvent extends Event
      * @param ResponseInterface|null $lastResponse
      * @return self
      */
-    public function setLastResponse(ResponseInterface $lastResponse = null): HydrationEvent
+    public function setLastResponse(?ResponseInterface $lastResponse = null): HydrationEvent
     {
         $this->lastResponse = $lastResponse;
 

--- a/lib/Tmdb/Event/Listener/Logger/LogApiErrorListener.php
+++ b/lib/Tmdb/Event/Listener/Logger/LogApiErrorListener.php
@@ -40,7 +40,7 @@ class LogApiErrorListener
      * @param LoggerInterface $logger
      * @param TmdbApiExceptionFormatterInterface|null $formatter
      */
-    public function __construct(LoggerInterface $logger, TmdbApiExceptionFormatterInterface $formatter = null)
+    public function __construct(LoggerInterface $logger, ?TmdbApiExceptionFormatterInterface $formatter = null)
     {
         $this->logger = $logger;
         $this->formatter = $formatter ?: new SimpleTmdbApiExceptionFormatter();

--- a/lib/Tmdb/Event/Listener/Logger/LogHttpMessageListener.php
+++ b/lib/Tmdb/Event/Listener/Logger/LogHttpMessageListener.php
@@ -44,7 +44,7 @@ class LogHttpMessageListener
      * @param LoggerInterface $logger
      * @param HttpMessageFormatterInterface|null $formatter
      */
-    public function __construct(LoggerInterface $logger, HttpMessageFormatterInterface $formatter = null)
+    public function __construct(LoggerInterface $logger, ?HttpMessageFormatterInterface $formatter = null)
     {
         $this->logger = $logger;
         $this->formatter = $formatter ?: new SimpleHttpMessageFormatter();

--- a/lib/Tmdb/Event/Listener/Logger/LogHydrationListener.php
+++ b/lib/Tmdb/Event/Listener/Logger/LogHydrationListener.php
@@ -49,7 +49,7 @@ class LogHydrationListener
      */
     public function __construct(
         LoggerInterface $logger,
-        HydrationFormatterInterface $formatter = null,
+        ?HydrationFormatterInterface $formatter = null,
         bool $withData = false
     ) {
         $this->logger = $logger;

--- a/lib/Tmdb/Event/Listener/Request/SessionTokenRequestListener.php
+++ b/lib/Tmdb/Event/Listener/Request/SessionTokenRequestListener.php
@@ -23,7 +23,7 @@ use Tmdb\Token\Session\SessionToken;
 class SessionTokenRequestListener
 {
     /**
-     * @var string|SessionBearerToken|GuestSessionToken
+     * @var SessionToken
      */
     private $token;
 

--- a/lib/Tmdb/Event/Listener/Request/UserAgentRequestListener.php
+++ b/lib/Tmdb/Event/Listener/Request/UserAgentRequestListener.php
@@ -28,7 +28,7 @@ class UserAgentRequestListener
      * UserAgentRequestListener constructor.
      * @param string|null $userAgent
      */
-    public function __construct(string $userAgent = null)
+    public function __construct(?string $userAgent = null)
     {
         $this->userAgent = $userAgent ?? sprintf('php-tmdb/api/%s', Client::VERSION);
     }

--- a/lib/Tmdb/Event/RequestEvent.php
+++ b/lib/Tmdb/Event/RequestEvent.php
@@ -45,7 +45,7 @@ class RequestEvent extends StoppableEvent implements LoggableHttpEventInterface
      * @param RequestInterface $request
      * @param SessionToken|null $sessionToken
      */
-    public function __construct(RequestInterface $request, SessionToken $sessionToken = null)
+    public function __construct(RequestInterface $request, ?SessionToken $sessionToken = null)
     {
         $this->request = $request;
         $this->sessionToken = $sessionToken;
@@ -109,7 +109,7 @@ class RequestEvent extends StoppableEvent implements LoggableHttpEventInterface
      * @param SessionToken|null $sessionToken
      * @return self
      */
-    public function setSessionToken(SessionToken $sessionToken = null): RequestEvent
+    public function setSessionToken(?SessionToken $sessionToken = null): RequestEvent
     {
         $this->sessionToken = $sessionToken;
 

--- a/lib/Tmdb/Exception/TmdbApiException.php
+++ b/lib/Tmdb/Exception/TmdbApiException.php
@@ -81,9 +81,9 @@ class TmdbApiException extends Exception
     public function __construct(
         int $code,
         string $message,
-        RequestInterface $request = null,
-        ResponseInterface $response = null,
-        Exception $previous = null
+        ?RequestInterface $request = null,
+        ?ResponseInterface $response = null,
+        ?Exception $previous = null
     ) {
         parent::__construct($message, $code, $previous);
 

--- a/lib/Tmdb/HttpClient/HttpClient.php
+++ b/lib/Tmdb/HttpClient/HttpClient.php
@@ -197,7 +197,7 @@ class HttpClient
      * @param string|null $key
      * @return array|mixed
      */
-    public function getOptions(string $key = null)
+    public function getOptions(?string $key = null)
     {
         if ($key) {
             return isset($this->options[$key]) ? $this->options[$key] : null;

--- a/lib/Tmdb/Model/Collection/Images.php
+++ b/lib/Tmdb/Model/Collection/Images.php
@@ -209,9 +209,8 @@ class Images extends GenericCollection
 
         foreach ($this->data as $image) {
             /**
-             * @var $image Image
+             * @var Image $image
              */
-
             if ($image->getVoteAverage() > $voteAverage) {
                 $voteAverage = $image->getVoteAverage();
                 $currentImage = $image;

--- a/lib/Tmdb/Model/Common/GenericCollection.php
+++ b/lib/Tmdb/Model/Common/GenericCollection.php
@@ -375,7 +375,7 @@ class GenericCollection implements ArrayAccess, IteratorAggregate, Countable
      *
      * @return array Returns an array of all matching key value pairs
      */
-    public function getAll(array $keys = null)
+    public function getAll(?array $keys = null)
     {
         return $keys ? array_intersect_key($this->data, array_flip($keys)) : $this->data;
     }

--- a/lib/Tmdb/Token/Session/RequestToken.php
+++ b/lib/Tmdb/Token/Session/RequestToken.php
@@ -63,7 +63,7 @@ class RequestToken
      * @param string|null $token
      * @return self
      */
-    public function setToken(string $token = null)
+    public function setToken(?string $token = null)
     {
         $this->token = $token;
 

--- a/lib/Tmdb/Token/Session/SessionToken.php
+++ b/lib/Tmdb/Token/Session/SessionToken.php
@@ -42,7 +42,7 @@ class SessionToken
      *
      * @param string|null $sessionToken
      */
-    public function __construct(string $sessionToken = null)
+    public function __construct(?string $sessionToken = null)
     {
         $this->sessionToken = $sessionToken;
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,14 +56,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated method getReleases\\(\\) of class Tmdb\\\\Model\\\\Movie\\:
-				Use the getReleaseDates instead$#
-			"""
-			count: 1
-			path: lib/Tmdb/Repository/MovieRepository.php
-
-		-
-			message: """
 				#^Return type of method Tmdb\\\\Repository\\\\MovieRepository\\:\\:getReleases\\(\\) has typehint with deprecated class Tmdb\\\\Model\\\\Movie\\\\Release\\:
 				Use ReleaseDate instead$#
 			"""

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -42,6 +42,11 @@ parameters:
 			path: lib/Tmdb/Factory/MovieFactory.php
 
 		-
+			message: "#^Return type \\(Tmdb\\\\Model\\\\Collection\\\\People\\) of method Tmdb\\\\Factory\\\\PeopleFactory\\:\\:createCollection\\(\\) should be compatible with return type \\(Tmdb\\\\Model\\\\Common\\\\GenericCollection\\<Tmdb\\\\Model\\\\AbstractModel\\>\\) of method Tmdb\\\\Factory\\\\AbstractFactory\\<Tmdb\\\\Model\\\\AbstractModel\\>\\:\\:createCollection\\(\\)$#"
+			count: 1
+			path: lib/Tmdb/Factory/PeopleFactory.php
+
+		-
 			message: "#^Property Tmdb\\\\HttpClient\\\\HttpClient\\:\\:\\$sessionToken is never written, only read\\.$#"
 			count: 1
 			path: lib/Tmdb/HttpClient/HttpClient.php


### PR DESCRIPTION
This pull request fixes implicitly marking parameter as it was deprecated in PHP 8.4.

It also fixes some other static analysis errors and simplifies the php version requirements in composer.json file ([the proof](https://semver.madewithlove.com/?package=php&constraint=%5E7.3+%7C%7C+%5E8.0) that this updated version requirement covers the same versions as the previous one).