### PR TITLE
Support symfony/options-resolver 8 (fixes #290)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
-        "symfony/options-resolver": "^4.4 || ^5 || ^6 || ^7",
+        "symfony/options-resolver": "^4.4 || ^5 || ^6 || ^7 || ^8",
         "psr/cache": "^1 || ^2 || ^3",
         "psr/simple-cache": "^1 || ^2 || ^3",
         "psr/event-dispatcher": "^1",

--- a/lib/Tmdb/Client.php
+++ b/lib/Tmdb/Client.php
@@ -95,7 +95,7 @@ class Client
                 'base_uri' => null,
                 'api_token' => null,
                 'guest_session_token' => null,
-                'http' => function (OptionsResolver $optionsResolver) {
+                'http' => $http = function (OptionsResolver $optionsResolver) {
                     $optionsResolver->setDefaults(
                         [
                             'client' => null,
@@ -120,7 +120,7 @@ class Client
                     $optionsResolver->setAllowedTypes('stream_factory', [StreamFactoryInterface::class, 'null']);
                     $optionsResolver->setAllowedTypes('uri_factory', [UriFactoryInterface::class, 'null']);
                 },
-                'hydration' => function (OptionsResolver $optionsResolver) {
+                'hydration' => $hydration = function (OptionsResolver $optionsResolver) {
                     $optionsResolver->setDefaults(
                         [
                             'event_listener_handles_hydration' => false,
@@ -131,7 +131,7 @@ class Client
                     // @todo 4.1 validate these are actually models
                     $optionsResolver->setAllowedTypes('only_for_specified_models', ['array']);
                 },
-                'event_dispatcher' => function (OptionsResolver $optionsResolver) {
+                'event_dispatcher' => $eventDispatcher = function (OptionsResolver $optionsResolver) {
                     $optionsResolver->setDefaults(
                         [
                             'adapter' => null
@@ -143,6 +143,14 @@ class Client
                 }
             ]
         );
+
+        // symfony/options-resolver 8.0 removed nested-options-via-Closure passed to setDefaults();
+        // setOptions() is the replacement, available from 7.3.
+        if (method_exists($resolver, 'setOptions')) {
+            $resolver->setOptions('http', $http);
+            $resolver->setOptions('hydration', $hydration);
+            $resolver->setOptions('event_dispatcher', $eventDispatcher);
+        }
 
         $resolver->setRequired(
             [

--- a/lib/Tmdb/Client.php
+++ b/lib/Tmdb/Client.php
@@ -146,8 +146,9 @@ class Client
 
         // symfony/options-resolver 8.0 removed nested-options-via-Closure passed to setDefaults();
         // setOptions() is the replacement, available from 7.3. The runtime guard supports older
-        // versions still allowed by composer.json; PHPStan resolves against the installed version.
-        // @phpstan-ignore function.alreadyNarrowedType, function.impossibleType
+        // versions still allowed by composer.json; PHPStan tautology errors are silenced in
+        // phpstan-baseline.neon for both true and false outcomes (analysis runs against a single
+        // installed OptionsResolver version, but the guard is genuine across the supported range).
         if (method_exists($resolver, 'setOptions')) {
             $resolver->setOptions('http', $http);
             $resolver->setOptions('hydration', $hydration);

--- a/lib/Tmdb/Client.php
+++ b/lib/Tmdb/Client.php
@@ -147,7 +147,7 @@ class Client
         // symfony/options-resolver 8.0 removed nested-options-via-Closure passed to setDefaults();
         // setOptions() is the replacement, available from 7.3. The runtime guard supports older
         // versions still allowed by composer.json; PHPStan resolves against the installed version.
-        // @phpstan-ignore function.alreadyNarrowedType
+        // @phpstan-ignore function.alreadyNarrowedType, function.impossibleType
         if (method_exists($resolver, 'setOptions')) {
             $resolver->setOptions('http', $http);
             $resolver->setOptions('hydration', $hydration);

--- a/lib/Tmdb/Client.php
+++ b/lib/Tmdb/Client.php
@@ -145,7 +145,9 @@ class Client
         );
 
         // symfony/options-resolver 8.0 removed nested-options-via-Closure passed to setDefaults();
-        // setOptions() is the replacement, available from 7.3.
+        // setOptions() is the replacement, available from 7.3. The runtime guard supports older
+        // versions still allowed by composer.json; PHPStan resolves against the installed version.
+        // @phpstan-ignore function.alreadyNarrowedType
         if (method_exists($resolver, 'setOptions')) {
             $resolver->setOptions('http', $http);
             $resolver->setOptions('hydration', $hydration);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -18,6 +18,22 @@ parameters:
 			count: 1
 			path: lib/Tmdb/Event/Listener/Logger/LogHttpMessageListener.php
 
+		# The method_exists(setOptions) guard supports symfony/options-resolver versions both
+		# with and without the method. PHPStan resolves against the installed version on each
+		# CI job, so exactly one of these two outcomes fires per job; reportUnmatched silences
+		# the other.
+		-
+			rawMessage: "Call to function method_exists() with Symfony\\Component\\OptionsResolver\\OptionsResolver and 'setOptions' will always evaluate to true."
+			identifier: function.alreadyNarrowedType
+			reportUnmatched: false
+			path: lib/Tmdb/Client.php
+
+		-
+			rawMessage: "Call to function method_exists() with Symfony\\Component\\OptionsResolver\\OptionsResolver and 'setOptions' will always evaluate to false."
+			identifier: function.impossibleType
+			reportUnmatched: false
+			path: lib/Tmdb/Client.php
+
 		-
 			rawMessage: 'Parameter #3 $first of method Http\Client\Common\Plugin\AbstractCachePlugin::handleRequest() expects callable(Psr\Http\Message\RequestInterface): Http\Promise\Promise, Closure(): void given.'
 			identifier: argument.type

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,8 +19,14 @@ parameters:
 			path: lib/Tmdb/Event/Listener/Logger/LogHttpMessageListener.php
 
 		-
-			rawMessage: 'Parameter #3 $first of method Http\Client\Common\Plugin\CachePlugin::handleRequest() expects callable(Psr\Http\Message\RequestInterface): Http\Promise\Promise, Closure(): void given.'
+			rawMessage: 'Parameter #3 $first of method Http\Client\Common\Plugin\AbstractCachePlugin::handleRequest() expects callable(Psr\Http\Message\RequestInterface): Http\Promise\Promise, Closure(): void given.'
 			identifier: argument.type
+			count: 1
+			path: lib/Tmdb/Event/Listener/Psr6CachedRequestListener.php
+
+		-
+			rawMessage: 'Call to method handleRequest() of internal class Http\Client\Common\Plugin\AbstractCachePlugin from outside its root namespace Http.'
+			identifier: method.internalClass
 			count: 1
 			path: lib/Tmdb/Event/Listener/Psr6CachedRequestListener.php
 


### PR DESCRIPTION
## Summary

Fixes #290. The library crashed on `symfony/options-resolver` 8 with `Cannot use object of type Closure as array in Client.php:216` because v8.0 removed support for defining nested options by passing a `Closure` to `setDefaults()` (deprecated in 7.3, removed in 8.0). The closures stayed as raw default values and `$options['hydration']` arrived in `postResolve()` as a `Closure`.

## Changes

**Options-resolver fix** (`composer.json`, `lib/Tmdb/Client.php`):

- Widen the `symfony/options-resolver` constraint to `^4.4 || ^5 || ^6 || ^7 || ^8`.
- Bind the three nested resolvers (`http`, `hydration`, `event_dispatcher`) via `OptionsResolver::setOptions()` when available (introduced in 7.3), falling back to the legacy closure-as-default pattern on older versions. The original `setDefaults([...])` block is preserved almost verbatim — each nested closure is captured into a local via `'key' => $var = function (...)` and then re-bound afterwards.

**PHPStan baseline updates** (`phpstan-baseline.neon`):

- The `method_exists($resolver, 'setOptions')` guard is tautological from PHPStan's perspective on a given CI job (always-true when the installed OptionsResolver has the method, always-false otherwise), with different identifiers per outcome. Both outcomes are baselined with `reportUnmatched: false` so whichever fires per job gets silenced and the other entry sits idle without tripping the unmatched-ignore check.
- Unrelated drift: a `php-http/cache-plugin` release between #289's last-green CI on `4.1` (2026-01-30) and now moved `handleRequest()` to the new `@internal AbstractCachePlugin` parent, invalidating the existing `argument.type` ignore on `Psr6CachedRequestListener.php:106` and adding a new `method.internalClass` error. The repo has no `composer.lock`, so every CI run pulls the latest cache-plugin — `4.1` would also fail PHPStan on a fresh re-run today. Baseline refreshed accordingly. Long-term fix is to stop calling the internal parent method, tracked separately.

## Why a runtime branch instead of bumping the floor

`setOptions()` only exists from options-resolver 7.3, which requires PHP ≥ 8.2. Bumping the constraint to `^7.3 || ^8` would implicitly force the library to PHP 8.2+, breaking installs on the lib's currently-declared `"php": "^7.3 || ^8.0"` floor. The `method_exists()` guard preserves that floor at the cost of the two-entry baseline silencing.

## Coverage

The CI matrix in `.github/workflows/continuous-integration.yml` runs PHP 7.4–8.5 × {normal, low, dev}. With the constraint widened to `^8`, jobs on PHP ≥ 8.4 + `normal`/`dev` will now install options-resolver 8 and exercise the `setOptions()` path — the previous matrix passed only because the old constraint excluded v8 entirely, which is how #290 escaped detection. `low` jobs pin v4.4 and exercise the legacy fallback. All 59 PR checks green.

## Reviewer notes

- The reporter's other two items in #290 are non-issues: `symfony/options-resolver` is already in `require` (`composer.json:36`), and the PHP 8.4 implicit-nullable deprecation in `HttpClient::getOptions` was fixed in 5a9ea4c.
- Happy to split the cache-plugin baseline refresh into its own PR if you'd prefer the options-resolver diff isolated — it's bundled here only because CI was unmergeable without it.

## Test plan

- [x] CI green across the PHP 7.4–8.5 × {normal, low, dev} matrix
- [ ] Manual smoke: instantiate `Tmdb\Client` on PHP 8.4 with `symfony/options-resolver:^8` installed
- [ ] Manual smoke: instantiate `Tmdb\Client` on PHP 7.4 with `symfony/options-resolver:4.4` installed (legacy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)